### PR TITLE
banking twin: add GAIA banking-firm profile seed and reference alignment note

### DIFF
--- a/docs/banking-reference-alignment.md
+++ b/docs/banking-reference-alignment.md
@@ -1,0 +1,47 @@
+# Banking Reference Alignment
+
+## Purpose
+
+This note records the first external banking reference anchors for the GAIA banking-firm semantic seed.
+
+The current banking-firm profile and domain manifests are seed artifacts for the SocioProphet banking twin.
+They are **not** a claim of full external standard conformance.
+
+## Reference anchors
+
+### FIBO
+
+FIBO is the Financial Industry Business Ontology maintained by EDM Council and standardized through OMG.
+It is the primary ontology reference point for financial concepts, legal entities, instruments, loans, and related business semantics.
+
+Within the banking-twin work, FIBO should be used as a reference ontology for:
+- legal entity semantics
+- financial instrument and obligation semantics
+- loan and credit semantics
+- contract and party role semantics
+- reporting/risk terminology normalization
+
+### BIAN
+
+BIAN is the Banking Industry Architecture Network reference framework for banking interoperability,
+service domains, and semantic APIs.
+
+Within the banking-twin work, BIAN should be used as a reference architecture for:
+- banking service-domain decomposition
+- API and service boundary naming
+- business capability and service interaction framing
+- operational and coreless-banking service alignment
+
+## Working rule
+
+Use FIBO primarily for ontology and concept alignment.
+Use BIAN primarily for service-domain and operational boundary alignment.
+
+When the two overlap, prefer explicit mapping notes rather than silent conflation.
+
+## Immediate next step
+
+The next banking semantic tranche SHOULD:
+1. annotate candidate domain overlaps with relevant FIBO areas,
+2. annotate runtime/service candidates with relevant BIAN service-domain references,
+3. record any mismatches as explicit divergence notes.

--- a/examples/banking-twin-minimal/legal-entity.bank-hc.json
+++ b/examples/banking-twin-minimal/legal-entity.bank-hc.json
@@ -1,0 +1,13 @@
+{
+  "id": "entity:banking-hc-001",
+  "entity_type": "holding-company",
+  "jurisdiction": "US",
+  "name": "Synthetic Banking Holding Co",
+  "regulator_refs": [
+    "regulator://federal-reserve"
+  ],
+  "attrs": {
+    "reporting_currency": "USD",
+    "status": "active"
+  }
+}

--- a/gaia/domains/balance-sheet/manifest.json
+++ b/gaia/domains/balance-sheet/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "gaia.domain.balance-sheet",
+  "version": "0.1.0",
+  "profile_affinity": [
+    "banking-firm"
+  ],
+  "primary_entities": [
+    "asset",
+    "liability",
+    "cashflow",
+    "funding-source"
+  ],
+  "primary_observations": [
+    "balance",
+    "maturity",
+    "rate",
+    "currency"
+  ],
+  "primary_actions": [
+    "ingest",
+    "aggregate",
+    "project",
+    "audit"
+  ],
+  "description": "Balance-sheet and funding structure domain for banking-firm state and projection work."
+}

--- a/gaia/domains/bank-core/manifest.json
+++ b/gaia/domains/bank-core/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "gaia.domain.bank-core",
+  "version": "0.1.0",
+  "profile_affinity": [
+    "banking-firm"
+  ],
+  "primary_entities": [
+    "legal-entity",
+    "business-unit",
+    "portfolio",
+    "counterparty"
+  ],
+  "primary_observations": [
+    "status",
+    "ownership",
+    "jurisdiction",
+    "lineage"
+  ],
+  "primary_actions": [
+    "reconcile",
+    "classify",
+    "link",
+    "audit"
+  ],
+  "description": "Institutional structure and core identity domain for a banking-firm digital twin."
+}

--- a/gaia/domains/capital-rwa/manifest.json
+++ b/gaia/domains/capital-rwa/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "gaia.domain.capital-rwa",
+  "version": "0.1.0",
+  "profile_affinity": [
+    "banking-firm"
+  ],
+  "primary_entities": [
+    "capital-stack",
+    "rwa-snapshot",
+    "buffer",
+    "ratio-package"
+  ],
+  "primary_observations": [
+    "cet1",
+    "tier1",
+    "total-capital",
+    "rwa"
+  ],
+  "primary_actions": [
+    "rollforward",
+    "attribute",
+    "benchmark",
+    "audit"
+  ],
+  "description": "Capital and risk-weighted asset domain for banking-firm regulatory and internal capital views."
+}

--- a/gaia/domains/credit-wholesale/manifest.json
+++ b/gaia/domains/credit-wholesale/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "gaia.domain.credit-wholesale",
+  "version": "0.1.0",
+  "profile_affinity": [
+    "banking-firm"
+  ],
+  "primary_entities": [
+    "facility",
+    "obligor",
+    "collateral",
+    "rating"
+  ],
+  "primary_observations": [
+    "pd",
+    "lgd",
+    "ead",
+    "delinquency-status"
+  ],
+  "primary_actions": [
+    "score",
+    "segment",
+    "stress",
+    "audit"
+  ],
+  "description": "Wholesale and institutional credit-risk domain for banking-firm portfolios."
+}

--- a/gaia/domains/regulatory-reporting/manifest.json
+++ b/gaia/domains/regulatory-reporting/manifest.json
@@ -1,0 +1,26 @@
+{
+  "id": "gaia.domain.regulatory-reporting",
+  "version": "0.1.0",
+  "profile_affinity": [
+    "banking-firm"
+  ],
+  "primary_entities": [
+    "filing-pack",
+    "line-item",
+    "correction-chain",
+    "signoff"
+  ],
+  "primary_observations": [
+    "publication-status",
+    "as-of-date",
+    "lineage-completeness",
+    "correction-status"
+  ],
+  "primary_actions": [
+    "assemble",
+    "publish",
+    "correct",
+    "audit"
+  ],
+  "description": "Regulatory and management reporting domain for filing packs, corrections, and evidence lineage."
+}

--- a/gaia/profiles/banking-firm/manifest.json
+++ b/gaia/profiles/banking-firm/manifest.json
@@ -1,0 +1,22 @@
+{
+  "id": "gaia.profile.banking-firm",
+  "version": "0.1.0",
+  "scope": "institution-portfolio-capital-liquidity-reporting",
+  "core_contracts": [
+    "entity",
+    "relation",
+    "state",
+    "observation",
+    "action",
+    "policy",
+    "provenance",
+    "evidence"
+  ],
+  "control_modes": [
+    "observe",
+    "simulate",
+    "plan",
+    "audit"
+  ],
+  "description": "Banking firm digital twin profile for legal entities, portfolios, capital, liquidity, and regulated reporting surfaces."
+}

--- a/schemas/banking/legal-entity.schema.json
+++ b/schemas/banking/legal-entity.schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "BankingTwinLegalEntity",
+  "type": "object",
+  "required": [
+    "id",
+    "entity_type",
+    "jurisdiction",
+    "name"
+  ],
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "entity_type": {
+      "type": "string",
+      "enum": [
+        "holding-company",
+        "bank",
+        "broker-dealer",
+        "branch",
+        "subsidiary"
+      ]
+    },
+    "jurisdiction": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "regulator_refs": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "attrs": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
# banking twin: add GAIA banking-firm profile seed and reference alignment note

## Summary

This draft PR stages the first GAIA banking-firm semantic seed.

Included in this tranche:
- `gaia/profiles/banking-firm/manifest.json`
- first banking domain manifests:
  - `bank-core`
  - `balance-sheet`
  - `credit-wholesale`
  - `capital-rwa`
  - `regulatory-reporting`
- seed banking legal-entity schema
- minimal synthetic banking legal-entity example
- `docs/banking-reference-alignment.md`

## Why this tranche exists

This is the first semantic incubation step for the SocioProphet banking-firm digital twin.
It is intentionally seed-grade and additive.

## Reference alignment

This PR explicitly names:
- **FIBO** as the ontology reference anchor for financial/business semantics
- **BIAN** as the service-domain and interoperability reference anchor for banking operational boundaries

At this stage, the PR records those as reference alignments rather than claiming full conformance.

## Scope boundaries

This tranche is intentionally incomplete.
It does **not** yet update:
- `gaia/registry.json`
- `schemas/index.json`

Those index/registry updates should follow once reviewers confirm the initial banking-firm semantic direction.

## Suggested review focus

- confirm the banking-firm profile and first domains are directionally correct
- confirm FIBO and BIAN are the right external anchors for follow-on mapping work
- confirm the seed tranche is appropriately narrow and additive
