### PR TITLE
gaia: add Michael human twin instance-plane starter tranche

### DIFF
--- a/gaia/actions/michael-observe-audit-plan-actuate.md
+++ b/gaia/actions/michael-observe-audit-plan-actuate.md
@@ -1,0 +1,24 @@
+# Michael — Observe → Audit → Plan → Actuate
+
+## Purpose
+
+This note records the instance-plane operating pattern for Michael inside the GAIA world-model repo.
+
+## Flow
+
+1. **Observe**
+   - collect bounded observations from subject-approved sources
+   - materialize subject/twin state updates
+2. **Audit**
+   - evaluate evidence completeness, provenance, and policy status
+   - attach belief snapshots and candidate-law references
+3. **Plan**
+   - derive belief-state updates and candidate equations under current constraints
+   - prepare promotion/gate context for downstream governance lanes
+4. **Actuate**
+   - emit only policy- and consent-admissible outputs
+   - hand governed actions and artifacts to downstream runtime/governance surfaces
+
+## Discipline
+
+The human digital twin is a bounded projection under consent. It is not the human subject and not an unbounded mirror.

--- a/gaia/twins/human/sample-belief-snapshot.json
+++ b/gaia/twins/human/sample-belief-snapshot.json
@@ -1,0 +1,23 @@
+{
+  "belief_state_id": "belief://michael/0001",
+  "world_ref": "world://gaia/local/0001",
+  "ontology_context_ref": "ontology://ontogenesis/michael-belief",
+  "truth_status": "believed_truth",
+  "engine": {
+    "family": "psl",
+    "version": "0.0.1"
+  },
+  "inputs": {
+    "grounded_assertions": ["assertion://human/0001"],
+    "observation_records": ["observation://wearable/0001", "observation://clinical/0001"],
+    "rule_templates": ["rule-template://michael/0001"]
+  },
+  "outputs": {
+    "posterior_atoms": ["atom://michael/0001"],
+    "weighted_rules": ["rule://michael/0001"],
+    "hypotheses": ["hypothesis://michael/0001"]
+  },
+  "methodology_snapshot_ref": "methodology://michael/0001",
+  "evidence_packet_ref": "evidence://michael/0001",
+  "promotion_status": "candidate"
+}

--- a/gaia/twins/human/sample-candidate-law-attachment.json
+++ b/gaia/twins/human/sample-candidate-law-attachment.json
@@ -1,0 +1,26 @@
+{
+  "candidate_id": "candidate-law://michael/0001",
+  "truth_status": "candidate_law",
+  "target_ref": "quantity://human/0001/biomarker",
+  "engine": {
+    "family": "pysr",
+    "version": "0.0.1"
+  },
+  "expression": {
+    "canonical": "x0 + 0.5 * x1",
+    "latex": "x_0 + 0.5 x_1"
+  },
+  "fit": {
+    "rmse": 0.12,
+    "r2": 0.91
+  },
+  "constraints": {
+    "dimensional_consistency": "pass",
+    "complexity_budget": "within_budget"
+  },
+  "counterexamples": ["counterexample://michael/0001"],
+  "derived_soft_rules": ["soft-rule://michael/0001"],
+  "methodology_snapshot_ref": "methodology://michael/0001",
+  "evidence_packet_ref": "evidence://michael/0001",
+  "promotion_status": "candidate"
+}

--- a/gaia/twins/human/sample-subject-state.json
+++ b/gaia/twins/human/sample-subject-state.json
@@ -1,0 +1,19 @@
+{
+  "subject_ref": "subject://human/0001",
+  "twin_ref": "twin://human/0001",
+  "consent_envelope_ref": "consent://human/0001",
+  "projection_bounds": {
+    "allowed_modalities": ["wearable", "clinical"],
+    "allowed_purposes": ["machine_science", "safety_review"],
+    "retention_policy": "bounded-30d"
+  },
+  "memory_state_ref": "memory://human/0001",
+  "cognition_state_ref": "cognition://human/0001",
+  "observation_refs": [
+    "observation://wearable/0001",
+    "observation://clinical/0001"
+  ],
+  "belief_state_refs": ["belief://michael/0001"],
+  "candidate_law_refs": ["candidate-law://michael/0001"],
+  "policy_status": "active"
+}

--- a/gaia/twins/human/twin-schema.json
+++ b/gaia/twins/human/twin-schema.json
@@ -1,0 +1,28 @@
+{
+  "$id": "https://socioprophet.org/schema/michael/human_digital_twin_state.schema.json",
+  "type": "object",
+  "required": [
+    "kind",
+    "subject_ref",
+    "twin_ref",
+    "consent_envelope_ref",
+    "projection_bounds",
+    "memory_state_ref",
+    "cognition_state_ref",
+    "observation_refs",
+    "policy_status"
+  ],
+  "properties": {
+    "kind": { "const": "human_digital_twin_state" },
+    "subject_ref": { "type": "string" },
+    "twin_ref": { "type": "string" },
+    "consent_envelope_ref": { "type": "string" },
+    "projection_bounds": { "type": "object" },
+    "memory_state_ref": { "type": "string" },
+    "cognition_state_ref": { "type": "string" },
+    "observation_refs": { "type": "array" },
+    "belief_state_refs": { "type": "array" },
+    "candidate_law_refs": { "type": "array" },
+    "policy_status": { "enum": ["active", "restricted", "revoked"] }
+  }
+}


### PR DESCRIPTION
## Summary

Add the first Michael human-twin / belief / candidate-law starter tranche to the GAIA instance plane.

## Files included

- `gaia/twins/human/twin-schema.json`
- `gaia/twins/human/sample-subject-state.json`
- `gaia/twins/human/sample-belief-snapshot.json`
- `gaia/twins/human/sample-candidate-law-attachment.json`
- `gaia/actions/michael-observe-audit-plan-actuate.md`

## Why

This repo is the correct instance-plane home for subject/twin state, belief snapshots, candidate-law attachments, and observe→audit→plan→actuate discipline.

## Notes

This is intentionally a narrow starter tranche. It does not add runtime code; it gives the repo a concrete Michael-aligned twin and belief-state surface that can be linked to ontogenesis, prophet-platform, and the MLOps packs.
