### PR TITLE
Verify P0 GAIA contract fixtures

### DIFF
--- a/fixtures/verification/p0-gaia-contract-fixtures.trigger.json
+++ b/fixtures/verification/p0-gaia-contract-fixtures.trigger.json
@@ -1,0 +1,5 @@
+{
+  "verification": "p0-gaia-contract-fixtures",
+  "purpose": "Trigger PR-scoped Contract Fixtures workflow for chat-visible P0 verification.",
+  "non_product_artifact": true
+}


### PR DESCRIPTION
## Purpose

Trigger PR-scoped `Contract Fixtures` workflow so P0 closure can verify GAIA contract fixtures from chat/GitHub without local checkout execution.

## Scope

Adds a non-product verification marker under `fixtures/verification/` only.

## Acceptance

- `Contract Fixtures` workflow runs on this PR.
- Required fixture validation checks pass.

This PR should be closed after verification; it is not intended to merge.