### PR TITLE
Add security-intel source pinning lane

### DIFF
--- a/.github/workflows/security-intel-source-pins.yml
+++ b/.github/workflows/security-intel-source-pins.yml
@@ -1,0 +1,37 @@
+name: security-intel-source-pins
+
+on:
+  pull_request:
+    paths:
+      - "docs/SECURITY_INTEL_SOURCE_PINNING.md"
+      - "gaia/cv/security_intel_source_pins.schema.json"
+      - "gaia/cv/security_intel_source_pins.example.json"
+      - "scripts/validate_security_intel_source_pins.py"
+      - ".github/workflows/security-intel-source-pins.yml"
+      - "docs/README.md"
+      - "README.md"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/SECURITY_INTEL_SOURCE_PINNING.md"
+      - "gaia/cv/security_intel_source_pins.schema.json"
+      - "gaia/cv/security_intel_source_pins.example.json"
+      - "scripts/validate_security_intel_source_pins.py"
+      - ".github/workflows/security-intel-source-pins.yml"
+      - "docs/README.md"
+      - "README.md"
+
+permissions:
+  contents: read
+
+jobs:
+  validate-security-intel-source-pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Validate security-intel source pins
+        run: python3 scripts/validate_security_intel_source_pins.py

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 - **FAQ** – `FAQ.md`
 - **Attribution Policy** — `ATTRIBUTION_POLICY.md`
 - **CV Storage Policy** – `CV_STORAGE_POLICY.md`
+- **Security-Intel Source Pinning** — `SECURITY_INTEL_SOURCE_PINNING.md`
 - **Releases** – `RELEASES.md`
 - **Changelog / Integration Log** — `CHANGELOG.md`, `INTEGRATION_LOG.md`
 
@@ -17,6 +18,6 @@ If you’re new: read **ABOUT → GETTING_STARTED → ARCHITECTURE**.
 - **Registry Contract** - `contracts/REGISTRY_CONTRACT.md`
 - **Workflow IR** - `workflows/WORKFLOW_IR.md`
 - **Assessment Scorecards** - `assessment/SCORECARDS.md`
-\n\n- **TritRPC Integration** — `contracts/TRITRPC_INTEGRATION.md`\n
+- **TritRPC Integration** — `contracts/TRITRPC_INTEGRATION.md`
 - **TritRPC Integration (Path A)** — `integrations/TRITRPC.md`
 - **TritRPC Wire Map (hyper.v1, Path A)** — `../gaia/wire/tritrpc/hyper.v1.pathA.json`

--- a/docs/SECURITY_INTEL_SOURCE_PINNING.md
+++ b/docs/SECURITY_INTEL_SOURCE_PINNING.md
@@ -1,0 +1,72 @@
+# Security-Intel Source Pinning
+
+Status: draft v0.1
+
+## Purpose
+
+GAIA provides the source-pinning and provenance lane for public security-intelligence inputs used by SCOPE-D, Ontogenesis, Prophet Platform, Prophet Workspace, Memory Mesh, and ProCybernetica scenario work.
+
+This lane records where public security-intel material came from, how it was classified, and what it is allowed to support. It does not promote public intelligence into local observation, attribution, authorization, or action.
+
+## What this lane pins
+
+The lane may pin:
+
+- MITRE ATT&CK release and documentation sources;
+- MITRE ATLAS release and documentation sources;
+- vendor reports;
+- public incident reports;
+- advisories;
+- regulatory or legal references;
+- taxonomy references used by Ontogenesis alignment work;
+- external reports cited by SCOPE-D adversarial scenarios.
+
+## Boundary
+
+A pinned public source is external evidence support only.
+
+It is not:
+
+- proof of local compromise;
+- attribution;
+- engagement authorization;
+- runtime authority;
+- procedure execution authority;
+- claim promotion;
+- memory writeback approval;
+- production observation;
+- permission to scan, probe, exploit, deliver payloads, or mutate state.
+
+## Required metadata
+
+A security-intel source pin should record:
+
+- stable source ID;
+- source class;
+- title;
+- publisher or maintainer;
+- source URL;
+- retrieval timestamp or intended retrieval timestamp;
+- hash status;
+- license/terms posture;
+- allowed downstream uses;
+- forbidden downstream uses;
+- related scenario or ontology references;
+- provenance notes.
+
+## Storage posture
+
+Small manifest records live in normal git.
+
+Large copied artifacts, when allowed by terms and useful for reproducibility, should follow the normal GAIA Curation Vault storage policy. If terms or size make copying inappropriate, the pin may remain URL/hash/provenance-only.
+
+## Downstream relationship
+
+- SCOPE-D may reference pinned source IDs as external support for scenarios.
+- Ontogenesis may reference pinned source IDs for generated import provenance.
+- Prophet Platform may consume scenario references that cite GAIA source pins.
+- Memory Mesh may carry scenario learning that references source pins, but durable writeback remains governed elsewhere.
+
+## Acceptance rule
+
+No downstream system may treat a GAIA security-intel source pin as sufficient authority, sufficient evidence, local attribution, or claim promotion by itself.

--- a/gaia/cv/security_intel_source_pins.example.json
+++ b/gaia/cv/security_intel_source_pins.example.json
@@ -1,0 +1,79 @@
+{
+  "schemaVersion": "0.1.0",
+  "kind": "SecurityIntelSourcePins",
+  "pins": [
+    {
+      "sourceId": "security-intel-source:mitre-attack-home-2026-05-29",
+      "sourceClass": "mitre_attack",
+      "title": "MITRE ATT&CK knowledge base landing page",
+      "publisher": "MITRE",
+      "sourceUrl": "https://attack.mitre.org/",
+      "retrievedAt": "2026-05-29T13:45:00Z",
+      "hashStatus": "not_copied_url_only",
+      "artifactHash": null,
+      "licensePosture": "public_web_reference",
+      "allowedUses": [
+        "external taxonomy reference",
+        "scenario technique annotation support",
+        "Ontogenesis alignment provenance support"
+      ],
+      "forbiddenUses": [
+        "local compromise proof",
+        "attribution",
+        "runtime authority",
+        "engagement authorization",
+        "claim promotion",
+        "memory writeback approval"
+      ],
+      "nonClaims": [
+        "does_not_prove_local_compromise",
+        "does_not_authorize_engagement",
+        "does_not_execute_attack_procedure",
+        "does_not_claim_attribution",
+        "does_not_promote_memory_writeback"
+      ],
+      "relatedRefs": [
+        "SocioProphet/SCOPE-D#60",
+        "SocioProphet/ontogenesis#112",
+        "adversarial-scenario:workspace-transduction-001"
+      ],
+      "provenanceNotes": "URL-only pin for public ATT&CK reference material used as taxonomy support. No ATT&CK corpus is vendored by this record."
+    },
+    {
+      "sourceId": "security-intel-source:mitre-atlas-home-2026-05-29",
+      "sourceClass": "mitre_atlas",
+      "title": "MITRE ATLAS knowledge base landing page",
+      "publisher": "MITRE",
+      "sourceUrl": "https://atlas.mitre.org/",
+      "retrievedAt": "2026-05-29T13:45:00Z",
+      "hashStatus": "not_copied_url_only",
+      "artifactHash": null,
+      "licensePosture": "public_web_reference",
+      "allowedUses": [
+        "external AI security taxonomy reference",
+        "agentic scenario annotation support",
+        "Ontogenesis alignment provenance support"
+      ],
+      "forbiddenUses": [
+        "local compromise proof",
+        "attribution",
+        "runtime authority",
+        "engagement authorization",
+        "claim promotion",
+        "memory writeback approval"
+      ],
+      "nonClaims": [
+        "does_not_prove_local_compromise",
+        "does_not_authorize_engagement",
+        "does_not_execute_attack_procedure",
+        "does_not_claim_attribution",
+        "does_not_promote_memory_writeback"
+      ],
+      "relatedRefs": [
+        "SocioProphet/ontogenesis#112",
+        "adversarial-scenario:workspace-transduction-001"
+      ],
+      "provenanceNotes": "URL-only pin for public ATLAS reference material used as taxonomy support. No ATLAS corpus is vendored by this record."
+    }
+  ]
+}

--- a/gaia/cv/security_intel_source_pins.schema.json
+++ b/gaia/cv/security_intel_source_pins.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://socioprophet.org/schemas/gaia/security-intel-source-pins.schema.json",
+  "title": "GAIA Security Intel Source Pins",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "pins"],
+  "properties": {
+    "schemaVersion": { "const": "0.1.0" },
+    "kind": { "const": "SecurityIntelSourcePins" },
+    "pins": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "sourceId",
+          "sourceClass",
+          "title",
+          "publisher",
+          "sourceUrl",
+          "retrievedAt",
+          "hashStatus",
+          "licensePosture",
+          "allowedUses",
+          "forbiddenUses",
+          "nonClaims",
+          "relatedRefs",
+          "provenanceNotes"
+        ],
+        "properties": {
+          "sourceId": { "type": "string", "pattern": "^security-intel-source:[a-z0-9][a-z0-9._:-]*$" },
+          "sourceClass": { "enum": ["mitre_attack", "mitre_atlas", "vendor_report", "public_incident_report", "advisory", "regulatory_reference", "taxonomy_reference", "other_public_source"] },
+          "title": { "type": "string", "minLength": 1 },
+          "publisher": { "type": "string", "minLength": 1 },
+          "sourceUrl": { "type": "string", "minLength": 1 },
+          "retrievedAt": { "type": "string", "format": "date-time" },
+          "hashStatus": { "enum": ["not_copied_url_only", "hash_pending", "hash_recorded", "not_applicable"] },
+          "artifactHash": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["algorithm", "value"],
+            "properties": {
+              "algorithm": { "enum": ["sha256", "sha512"] },
+              "value": { "type": "string", "minLength": 32 }
+            }
+          },
+          "licensePosture": { "enum": ["public_web_reference", "open_license", "terms_require_review", "unknown_requires_review"] },
+          "allowedUses": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "forbiddenUses": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+          "nonClaims": { "type": "array", "minItems": 4, "items": { "type": "string" } },
+          "relatedRefs": { "type": "array", "items": { "type": "string" } },
+          "provenanceNotes": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate_security_intel_source_pins.py
+++ b/scripts/validate_security_intel_source_pins.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Validate GAIA security-intel source pin examples."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "gaia" / "cv" / "security_intel_source_pins.schema.json"
+EXAMPLE = ROOT / "gaia" / "cv" / "security_intel_source_pins.example.json"
+
+
+def load(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check(name: str, ok: bool, detail=None):
+    return {"check": name, "passed": bool(ok), "detail": detail or []}
+
+
+def main() -> int:
+    schema = load(SCHEMA)
+    example = load(EXAMPLE)
+    out = []
+
+    out.append(check("schema-version", example.get("schemaVersion") == "0.1.0"))
+    out.append(check("kind", example.get("kind") == "SecurityIntelSourcePins"))
+    pins = example.get("pins", [])
+    out.append(check("pins-present", isinstance(pins, list) and len(pins) > 0))
+
+    required = set(schema.get("properties", {}).get("pins", {}).get("items", {}).get("required", []))
+    seen_ids = set()
+    for idx, pin in enumerate(pins):
+        prefix = f"pin-{idx}"
+        out.append(check(f"{prefix}-required-covered", required <= set(pin.keys()), [sorted(required - set(pin.keys()))]))
+        source_id = pin.get("sourceId", "")
+        out.append(check(f"{prefix}-source-id", isinstance(source_id, str) and source_id.startswith("security-intel-source:")))
+        out.append(check(f"{prefix}-source-id-unique", source_id not in seen_ids))
+        seen_ids.add(source_id)
+        out.append(check(f"{prefix}-url", str(pin.get("sourceUrl", "")).startswith("https://")))
+        out.append(check(f"{prefix}-retrieved-at", str(pin.get("retrievedAt", "")).endswith("Z")))
+        out.append(check(f"{prefix}-allowed-uses", isinstance(pin.get("allowedUses"), list) and len(pin["allowedUses"]) > 0))
+        out.append(check(f"{prefix}-forbidden-uses", isinstance(pin.get("forbiddenUses"), list) and len(pin["forbiddenUses"]) > 0))
+        forbidden = set(pin.get("forbiddenUses", []))
+        for forbidden_use in [
+            "local compromise proof",
+            "attribution",
+            "runtime authority",
+            "engagement authorization",
+            "claim promotion",
+            "memory writeback approval",
+        ]:
+            out.append(check(f"{prefix}-forbid-{forbidden_use}", forbidden_use in forbidden))
+        non_claims = set(pin.get("nonClaims", []))
+        for non_claim in [
+            "does_not_prove_local_compromise",
+            "does_not_authorize_engagement",
+            "does_not_claim_attribution",
+            "does_not_promote_memory_writeback",
+        ]:
+            out.append(check(f"{prefix}-nonclaim-{non_claim}", non_claim in non_claims))
+        if pin.get("hashStatus") == "not_copied_url_only":
+            out.append(check(f"{prefix}-no-artifact-hash-for-url-only", pin.get("artifactHash") is None))
+        out.append(check(f"{prefix}-not-authority-in-notes", "authority" in pin.get("provenanceNotes", "") or "taxonomy support" in pin.get("provenanceNotes", "")))
+
+    passed = all(item["passed"] for item in out)
+    result = {"validator": "gaia.security_intel_source_pins.v0.1", "passed": passed, "results": out}
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if not passed:
+        print("FAIL: security-intel source pins", file=sys.stderr)
+        return 1
+    print("PASS: security-intel source pins")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Superseded by #34.

Reason: #30 diverged from current `main`. The same security-intel source-pinning lane has been replayed onto `security-intel-source-pinning-v2` from current main.