### PR TITLE
Add CHRONOS-carrier-compatible fields to WorldClaim/FusionExplanation (#38)

### DIFF
--- a/.github/workflows/contract-fixtures.yml
+++ b/.github/workflows/contract-fixtures.yml
@@ -8,6 +8,7 @@ on:
       - 'scripts/validate_contract_fixtures.py'
       - 'scripts/validate_multidomain_fixtures.py'
       - 'scripts/validate_bounded_osm_source_adapter.py'
+      - 'scripts/validate_chronos_carrier_fixtures.py'
       - 'scripts/ofif_to_gaia_bridge.py'
       - 'scripts/check_ofif_bridge_invariants.py'
       - 'scripts/soil_intelligence_fusion.py'
@@ -15,6 +16,7 @@ on:
       - 'geospatial/osm_ingest.py'
       - 'geospatial/osm_tile_export.py'
       - 'geospatial/osm_route_graph.py'
+      - 'geospatial/world_claim_ingest.py'
       - 'navigation/lidar_feature_extract.py'
       - 'navigation/lidar_rollback_receipt.py'
       - '.github/workflows/contract-fixtures.yml'
@@ -25,6 +27,7 @@ on:
       - 'scripts/validate_contract_fixtures.py'
       - 'scripts/validate_multidomain_fixtures.py'
       - 'scripts/validate_bounded_osm_source_adapter.py'
+      - 'scripts/validate_chronos_carrier_fixtures.py'
       - 'scripts/ofif_to_gaia_bridge.py'
       - 'scripts/check_ofif_bridge_invariants.py'
       - 'scripts/soil_intelligence_fusion.py'
@@ -32,6 +35,7 @@ on:
       - 'geospatial/osm_ingest.py'
       - 'geospatial/osm_tile_export.py'
       - 'geospatial/osm_route_graph.py'
+      - 'geospatial/world_claim_ingest.py'
       - 'navigation/lidar_feature_extract.py'
       - 'navigation/lidar_rollback_receipt.py'
       - '.github/workflows/contract-fixtures.yml'
@@ -56,6 +60,37 @@ jobs:
 
       - name: Validate bounded OSM source adapter fixtures
         run: python3 scripts/validate_bounded_osm_source_adapter.py
+
+      - name: Ingest OpenStreetMap fixture into a governed WorldClaim bundle
+        run: |
+          python3 geospatial/world_claim_ingest.py \
+            fixtures/geospatial/osm-feature-world-claim-input.sample.v1.json \
+            /tmp/gaia-world-claim-ingest-output.json
+
+      - name: Check governed WorldClaim ingest output (incl. CHRONOS carrier fields)
+        run: |
+          python3 - <<'PY'
+          import json
+          with open('/tmp/gaia-world-claim-ingest-output.json', 'r', encoding='utf-8') as handle:
+              doc = json.load(handle)
+          claim = doc['claims'][0]
+          trace = doc['explanation_traces'][0]
+          assert claim['policy_status']['status'] == 'proposed'
+          assert claim['uncertainty']['confidence_score'] == 0.85
+          assert claim['map_display']['display_layer'] == 'proposed_candidate'
+          assert doc['evidence_records'][0]['source_type'] == 'osm'
+          assert trace['fusion_rule']['rule_class'] == 'single_source_passthrough'
+          # CHRONOS carrier fields (SocioProphet/gaia-world-model#38): additive,
+          # non-breaking extension for WorldClaim/FusionExplanation.
+          assert claim['chronos_grounding_status'] == 'grounded'
+          assert claim['chronos_owning_authority_plane'] == 'SocioProphet/holmes'
+          assert trace['fusion_rule']['chronos_method_family'] == 'not_applicable'
+          assert trace['fusion_rule']['chronos_method_output_type'] == 'hard_value'
+          print('governed WorldClaim ingest output (incl. CHRONOS carrier fields) passed')
+          PY
+
+      - name: Validate CHRONOS carrier extension fixtures (WorldClaim/FusionExplanation)
+        run: python3 scripts/validate_chronos_carrier_fixtures.py
 
       - name: Convert OFIF observation into GAIA artifact
         run: |

--- a/docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md
+++ b/docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md
@@ -316,6 +316,31 @@ Agentplane may act on `admitted` world-claims subject to policy constraints. It 
 
 Schema root issue: SocioProphet/ontogenesis#77
 
+## CHRONOS carrier compatibility (SocioProphet/gaia-world-model#38)
+
+Sociosphere's `docs/integration/neurosymbolic-chronos-alignment.md` defines a "CHRONOS carrier" boundary: any object crossing a governance boundary that references neuro-symbolic reasoning must carry source evidence reference, method family, method output type, grounding status, validation status, explanation trace reference, owning authority plane, non-authority declaration, replay reference, and governance decision/pending. GAIA's `WorldClaim`/`FusionExplanation` contract already matched this shape closely. This is an **additive** extension — every field below is optional, `additionalProperties` stays `false` only at the level each field was added to, and no existing field, required list, or runtime behavior changed. Fixtures written before this change remain valid.
+
+| CHRONOS carrier concept | GAIA field | Status |
+| --- | --- | --- |
+| Source evidence reference | `WorldClaim.source_evidence_refs` | Already covered — no new field |
+| Method family | `FusionExplanation.fusion_rule.chronos_method_family` | **New.** Distinct from `rule_class`, which classifies GAIA's own fusion mechanics (weighted_mean, bayesian_update, ...), not neuro-symbolic technique |
+| Method output type | `FusionExplanation.fusion_rule.chronos_method_output_type` | **New.** `hard_value` by default; non-hard values (`fuzzy_satisfaction_score`, `truth_bound`, `symbolic_derivation`, `learned_rule_candidate`, `ontology_delta_candidate`, `policy_proposal`, `event_schema_candidate`) require a non-authority declaration |
+| Grounding status | `WorldClaim.chronos_grounding_status` | **New.** Distinct from `uncertainty.confidence_score`/`uncertainty_class`, which remain GAIA's existing confidence measure |
+| Validation status | `WorldClaim.policy_status` | Already covered — GAIA's contract has Holmes perform verify+govern as one step (see "Repo boundaries" above), so `policy_status.status` already carries both the CHRONOS "validation status" and "governance decision" roles. No new field |
+| Explanation trace reference | `WorldClaim.explanation_trace_ref` | Already covered — no new field |
+| Owning authority plane | `WorldClaim.chronos_owning_authority_plane` | **New.** Names which repo/plane holds final admission authority for this specific claim (e.g. `SocioProphet/holmes`) |
+| Non-authority declaration | `FusionExplanation.chronos_non_authority_declaration` | **New.** Required whenever `chronos_method_family`/`chronos_method_output_type` name a neuro-symbolic or soft-output method. Directly implements the CHRONOS negative rule "a fuzzy satisfaction score is promoted as truth": `is_candidate_only=true` plus `policy_status.status != admitted` must both hold |
+| Replay reference | `FusionExplanation.replay` | Already covered — no new field |
+| Governance decision or pending | `WorldClaim.policy_status.status` | Already covered — no new field |
+
+Worked examples:
+
+- `fixtures/geospatial/eo-osm-dem-fusion-world-claim.sample.v1.json` — classical weighted-mean fusion; `chronos_method_family=classical_deterministic`, `chronos_method_output_type=hard_value`, no non-authority declaration needed.
+- `fixtures/geospatial/ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json` — an LTN-style differentiable fuzzy-logic fusion producing a `fuzzy_satisfaction_score`; carries a full `chronos_non_authority_declaration` and is correctly held at `policy_status.status=review`, never `admitted`.
+- `fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json` — the same fuzzy-score fusion incorrectly promoted to `admitted` with no non-authority declaration; must be, and is, rejected.
+
+Validator: `scripts/validate_chronos_carrier_fixtures.py` (wired into `.github/workflows/contract-fixtures.yml`) checks both schemas declare the new fields as optional, validates the positive fixtures, and confirms the negative fixture is rejected.
+
 ## Non-goals (v0)
 
 - Live ingestion pipelines (fixtures and deterministic proofs only in this PR).

--- a/fixtures/geospatial/eo-osm-dem-fusion-world-claim.sample.v1.json
+++ b/fixtures/geospatial/eo-osm-dem-fusion-world-claim.sample.v1.json
@@ -105,7 +105,9 @@
     "classification": {
       "data_class": "public",
       "handling_tags": ["demo", "fusion", "world-claim", "risk", "provisional", "advisory"]
-    }
+    },
+    "chronos_grounding_status": "partially_grounded",
+    "chronos_owning_authority_plane": "SocioProphet/holmes"
   },
   "source_evidence": [
     {
@@ -284,7 +286,9 @@
       "rule_id": "weighted-mean-road-surface-risk-v1",
       "rule_class": "weighted_mean",
       "rule_version": "v1",
-      "rule_ref": "docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md#weighted-mean-fusion"
+      "rule_ref": "docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md#weighted-mean-fusion",
+      "chronos_method_family": "classical_deterministic",
+      "chronos_method_output_type": "hard_value"
     },
     "inputs": [
       {
@@ -395,6 +399,7 @@
     "map_display.display_layer is 'provisional_overlay' — uncertainty and expiry label required on /map.",
     "Weather validity window expires 2026-05-01T15:00Z — claim must be re-evaluated after expiry.",
     "No autonomous actuation permitted from provisional world claim.",
-    "VectorCandidate (if retrieved) is status=candidate_only and must not influence this claim's policy status."
+    "VectorCandidate (if retrieved) is status=candidate_only and must not influence this claim's policy status.",
+    "CHRONOS carrier (SocioProphet/gaia-world-model#38): chronos_method_family=classical_deterministic and chronos_method_output_type=hard_value, so no chronos_non_authority_declaration is required — this is an ordinary weighted-mean fusion, not a neuro-symbolic method."
   ]
 }

--- a/fixtures/geospatial/ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json
+++ b/fixtures/geospatial/ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json
@@ -1,0 +1,277 @@
+{
+  "artifact_version": "v1",
+  "artifact_type": "gaia.world_claim.fusion",
+  "artifact_id": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01",
+  "created_at": "2026-08-01T09:00:00Z",
+  "description": "Worked example: an LTN-style differentiable fuzzy-logic fusion over EO vegetation-dryness and weather precipitation-deficit evidence produces a fuzzy satisfaction score for the predicate HighFireRisk(corridor). This is the CHRONOS neuro-symbolic case referenced in sociosphere/docs/integration/neurosymbolic-chronos-alignment.md and SocioProphet/gaia-world-model#38: the fuzzy score is a candidate signal only, never truth, evidence, or a policy admission by itself.",
+  "standards_refs": [
+    "SocioProphet/socioprophet-standards-storage/docs/standards/096-multidomain-geospatial-storage-contracts.md",
+    "SocioProphet/socioprophet-standards-knowledge/docs/standards/080-multidomain-geospatial-knowledge-context.md"
+  ],
+  "claim": {
+    "claim_version": "v1",
+    "claim_id": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01",
+    "claim_type": "risk",
+    "geo_anchor": {
+      "anchor_id": "anchor:fusion:sonoma-corridor:2026-08-01",
+      "anchor_type": "bbox",
+      "bbox": [-122.75, 38.40, -122.65, 38.48],
+      "h3_cells": ["8928308280fffff", "89283082807ffff"],
+      "crs": "EPSG:4326",
+      "temporal": {
+        "observed_at": "2026-08-01T08:30:00Z",
+        "valid_from": "2026-08-01T08:00:00Z",
+        "valid_to": "2026-08-01T14:00:00Z",
+        "time_basis": "sensor_capture"
+      }
+    },
+    "source_evidence_refs": [
+      "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+      "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z"
+    ],
+    "proposed_value": {
+      "predicate": "HighFireRisk(sonoma-corridor)",
+      "fuzzy_satisfaction_score": 0.74,
+      "risk_domain": "wildland_fire_ignition_potential",
+      "notes": "LTN-style differentiable fuzzy-logic satisfaction score for the HighFireRisk predicate, combining vegetation dryness index and precipitation deficit. This is a soft constraint-satisfaction signal, not a hard risk determination."
+    },
+    "temporal_validity": {
+      "valid_from": "2026-08-01T08:00:00Z",
+      "valid_to": "2026-08-01T14:00:00Z",
+      "staleness_class": "recent",
+      "expiry_note": "Re-run fuzzy satisfaction scoring after next EO/weather refresh cycle."
+    },
+    "uncertainty": {
+      "confidence_score": 0.55,
+      "uncertainty_class": "high",
+      "uncertainty_notes": "Confidence reflects input evidence quality only. The 0.74 fuzzy_satisfaction_score in proposed_value is a separate, non-probabilistic soft-constraint value per chronos_method_output_type=fuzzy_satisfaction_score and MUST NOT be read as a confidence or probability of fire occurrence.",
+      "adversarial_impact": 0.0
+    },
+    "policy_status": {
+      "status": "review",
+      "review_reason": "Fuzzy satisfaction score from an LTN-style neuro-symbolic method is a candidate signal only (chronos_non_authority_declaration.is_candidate_only=true). Per CHRONOS negative rule 'a fuzzy satisfaction score is promoted as truth', this claim must not be admitted or treated as evidence until Holmes/Policy reviews it against hard sensor/field evidence.",
+      "constraints": [
+        "display-advisory-only",
+        "must-not-be-treated-as-evidence",
+        "no-autonomous-actuation",
+        "requires-policy-review-before-admission",
+        "requires-corroborating-hard-evidence-before-any-admission"
+      ]
+    },
+    "explanation_trace_ref": "trace:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01",
+    "map_display": {
+      "show_source_attribution": true,
+      "show_uncertainty": true,
+      "show_evidence_chain": true,
+      "show_policy_status": true,
+      "display_layer": "review_flagged",
+      "advisory_label": "Candidate fuzzy fire-risk signal (LTN-style) — under review, not admitted, not evidence"
+    },
+    "attribution": {
+      "primary_source_name": "Fusion: Synthetic EO vegetation-dryness scene + synthetic weather precipitation-deficit reanalysis",
+      "license_refs": ["sample-only", "copernicus-era5-sample"],
+      "attribution_texts": [
+        "EO scene: synthetic fixture for GAIA runtime validation",
+        "Weather: ERA5-like synthetic fixture for GAIA runtime validation"
+      ],
+      "attribution_notes": "Synthetic fixture values only; not derived from live sensor feeds."
+    },
+    "provenance": {
+      "chain": ["runtime:world-claim-ltn-fusion:v0"],
+      "derived_from": [
+        "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+        "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z"
+      ],
+      "runtime_ref": "runtime:world-claim-ltn-fusion:v0",
+      "created_at": "2026-08-01T09:00:00Z",
+      "content_hash": "sha256:fixture-placeholder-replace-with-canonical-hash"
+    },
+    "classification": {
+      "data_class": "public",
+      "handling_tags": ["demo", "fusion", "world-claim", "risk", "review", "advisory", "neuro-symbolic", "ltn"]
+    },
+    "chronos_grounding_status": "ungrounded",
+    "chronos_owning_authority_plane": "SocioProphet/holmes"
+  },
+  "source_evidence": [
+    {
+      "evidence_version": "v1",
+      "evidence_id": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+      "source_type": "eo_stac",
+      "source_ref": "stac:item:vegetation-dryness-scene-002",
+      "geo_anchor_ref": "anchor:fusion:sonoma-corridor:2026-08-01",
+      "content_hash": "sha256:fixture-placeholder",
+      "attribution": {
+        "source_name": "Synthetic vegetation-dryness EO fixture",
+        "license_ref": "sample-only",
+        "attribution_text": "Synthetic EO fixture for GAIA runtime validation"
+      },
+      "temporal": {
+        "observed_at": "2026-08-01T08:30:00Z",
+        "valid_from": "2026-08-01T08:25:00Z",
+        "valid_to": "2026-08-01T08:35:00Z",
+        "staleness_class": "recent"
+      },
+      "confidence": {
+        "score": 0.70,
+        "confidence_class": "moderate",
+        "notes": "Synthetic NDMI (moisture index) derivation."
+      },
+      "spatial_summary": {
+        "geometry_type": "Polygon",
+        "h3_cells": ["8928308280fffff", "89283082807ffff"],
+        "bbox": [-122.75, 38.40, -122.65, 38.48],
+        "crs": "EPSG:4326"
+      },
+      "source_metadata": {
+        "platform": "synthetic-sat-002",
+        "instruments": ["synthetic-optical-payload"],
+        "derived_indices": ["NDMI"],
+        "ndmi_value": -0.31,
+        "stac_item_ref": "stac:item:vegetation-dryness-scene-002"
+      },
+      "classification": {
+        "data_class": "public",
+        "handling_tags": ["demo", "eo", "stac", "source-evidence"]
+      }
+    },
+    {
+      "evidence_version": "v1",
+      "evidence_id": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z",
+      "source_type": "weather_reanalysis",
+      "source_ref": "reanalysis://era5-like/sonoma-corridor/2026-08-01T08:00:00Z",
+      "geo_anchor_ref": "anchor:fusion:sonoma-corridor:2026-08-01",
+      "content_hash": "sha256:fixture-placeholder",
+      "attribution": {
+        "source_name": "ERA5-like weather reanalysis (synthetic fixture)",
+        "license_ref": "copernicus-era5-sample",
+        "attribution_text": "ERA5-like synthetic fixture for GAIA runtime validation"
+      },
+      "temporal": {
+        "observed_at": "2026-08-01T08:00:00Z",
+        "valid_from": "2026-08-01T06:00:00Z",
+        "valid_to": "2026-08-01T14:00:00Z",
+        "staleness_class": "recent"
+      },
+      "confidence": {
+        "score": 0.68,
+        "confidence_class": "moderate",
+        "notes": "30-day precipitation deficit relative to seasonal norm; grid-scale reanalysis limits micro-scale precision."
+      },
+      "spatial_summary": {
+        "geometry_type": "Polygon",
+        "h3_cells": ["8928308280fffff", "89283082807ffff"],
+        "bbox": [-123.0, 38.2, -122.4, 38.6],
+        "crs": "EPSG:4326"
+      },
+      "source_metadata": {
+        "reanalysis_model": "ERA5-like (synthetic)",
+        "resolution_km": 31,
+        "precip_deficit_30d_pct": 62.0,
+        "notes": "Synthetic fixture values for GAIA validation only"
+      },
+      "classification": {
+        "data_class": "public",
+        "handling_tags": ["demo", "weather", "reanalysis", "era5", "source-evidence"]
+      }
+    }
+  ],
+  "explanation_trace": {
+    "trace_version": "v1",
+    "trace_id": "trace:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01",
+    "claim_ref": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01",
+    "fusion_rule": {
+      "rule_id": "ltn-fuzzy-high-fire-risk-v1",
+      "rule_class": "model_inference",
+      "rule_version": "v1",
+      "rule_ref": "sociosphere/docs/integration/neurosymbolic-chronos-alignment.md#method-families-and-chronos-roles",
+      "chronos_method_family": "ltn_differentiable_fuzzy_logic",
+      "chronos_method_output_type": "fuzzy_satisfaction_score"
+    },
+    "inputs": [
+      {
+        "evidence_ref": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+        "role": "primary",
+        "weight": 0.55,
+        "confidence_at_fusion": 0.70,
+        "notes": "Vegetation moisture index (NDMI) feeds the differentiable fuzzy predicate Dry(vegetation)."
+      },
+      {
+        "evidence_ref": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z",
+        "role": "corroborating",
+        "weight": 0.45,
+        "confidence_at_fusion": 0.68,
+        "notes": "Precipitation deficit feeds the differentiable fuzzy predicate Drought(region)."
+      }
+    ],
+    "steps": [
+      {
+        "step_id": "step-normalize-ndmi",
+        "step_type": "normalize",
+        "input_refs": ["evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01"],
+        "output_ref": "normalized:eo:ndmi:-0.31",
+        "step_notes": "Extract NDMI=-0.31 (dry vegetation signal)."
+      },
+      {
+        "step_id": "step-normalize-precip-deficit",
+        "step_type": "normalize",
+        "input_refs": ["evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z"],
+        "output_ref": "normalized:weather:precip-deficit:62pct",
+        "step_notes": "Extract 30-day precipitation deficit=62% of seasonal norm."
+      },
+      {
+        "step_id": "step-infer-fuzzy-predicate",
+        "step_type": "infer",
+        "input_refs": ["normalized:eo:ndmi:-0.31", "normalized:weather:precip-deficit:62pct"],
+        "output_ref": "fuzzy-score:HighFireRisk:0.74",
+        "step_notes": "LTN-style differentiable fuzzy-logic layer computes satisfaction score 0.74 for predicate HighFireRisk(corridor) = Dry(vegetation) AND Drought(region), using a t-norm combination of the two grounded fuzzy predicates. This is a soft constraint-satisfaction value, not a probability or ground-truth risk score."
+      },
+      {
+        "step_id": "step-gate-non-authority",
+        "step_type": "gate",
+        "input_refs": ["fuzzy-score:HighFireRisk:0.74"],
+        "output_ref": "gated-claim:review",
+        "step_notes": "Per CHRONOS negative rule ('a fuzzy satisfaction score is promoted as truth'), policy_status is forced to 'review' and chronos_non_authority_declaration.is_candidate_only=true is attached. Admission requires Holmes/Policy review plus corroborating hard evidence."
+      }
+    ],
+    "uncertainty": {
+      "method": "model_calibration",
+      "combined_score": 0.55,
+      "uncertainty_class": "high",
+      "per_input_impact": [
+        {"evidence_ref": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01", "impact": 0.55},
+        {"evidence_ref": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z", "impact": 0.45}
+      ],
+      "notes": "combined_score is the fusion's ordinary evidence-quality confidence (uncertainty.method=model_calibration), and is intentionally distinct from proposed_value.fuzzy_satisfaction_score=0.74 (the LTN predicate-satisfaction value). Conflating the two is exactly what chronos_non_authority_declaration exists to prevent."
+    },
+    "replay": {
+      "mode": "model_snapshot",
+      "command": "cat fixtures/geospatial/ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[\"claim\"][\"proposed_value\"][\"fuzzy_satisfaction_score\"])'"
+    },
+    "provenance": {
+      "runtime_ref": "runtime:world-claim-ltn-fusion:v0",
+      "created_at": "2026-08-01T09:00:00Z",
+      "content_hash": "sha256:fixture-placeholder-replace-with-canonical-hash"
+    },
+    "chronos_non_authority_declaration": {
+      "is_candidate_only": true,
+      "declaration": "LTN-style differentiable fuzzy-logic satisfaction score for HighFireRisk(sonoma-corridor); advisory candidate signal only. Not evidence, not a policy admission, not canonical schema/ontology authority, and not a probability or ground-truth risk determination, until the owning authority plane (SocioProphet/holmes) reviews it against corroborating hard evidence.",
+      "forbidden_uses": [
+        "treating this fuzzy_satisfaction_score as evidence for WorldClaim admission",
+        "treating this fuzzy_satisfaction_score as a probability of fire occurrence",
+        "triggering autonomous actuation (e.g. alerts, routing changes) from this claim while policy_status is not admitted",
+        "promoting this claim to policy_status=admitted without Holmes/Policy review and corroborating hard sensor/field evidence"
+      ]
+    }
+  },
+  "invariants": [
+    "Both source evidences carry attribution, license ref, temporal validity, and confidence.",
+    "GeoAnchor binds the fused claim to a verifiable bbox with H3 cell coverage.",
+    "ExplanationTrace records the ltn_differentiable_fuzzy_logic method family and fuzzy_satisfaction_score output type.",
+    "policy_status.status is 'review', not 'admitted' — a fuzzy satisfaction score is never auto-admitted (CHRONOS negative rule 1).",
+    "chronos_non_authority_declaration.is_candidate_only is true, satisfying the requirement that any non-hard_value chronos_method_output_type carry an explicit non-authority declaration.",
+    "map_display.display_layer is 'review_flagged' — advisory label required on /map.",
+    "No autonomous actuation permitted from this claim.",
+    "uncertainty.confidence_score (evidence quality) is kept distinct from proposed_value.fuzzy_satisfaction_score (LTN predicate value) — the two must never be conflated."
+  ]
+}

--- a/fixtures/geospatial/negative/world-claim-fusion-rule-malformed-non-object.invalid.v1.json
+++ b/fixtures/geospatial/negative/world-claim-fusion-rule-malformed-non-object.invalid.v1.json
@@ -1,0 +1,181 @@
+{
+  "artifact_version": "v1",
+  "artifact_type": "gaia.world_claim.fusion",
+  "artifact_id": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-02:MALFORMED",
+  "created_at": "2026-08-02T09:00:00Z",
+  "description": "NEGATIVE FIXTURE (must be rejected with a clean CheckError, not a crash). Same LTN-style fuzzy_satisfaction_score fusion as ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json, but here explanation_trace.fusion_rule is malformed to a plain string instead of an object. This proves scripts/validate_chronos_carrier_fixtures.py's check_chronos_carrier() rejects a non-object fusion_rule with a readable CheckError message instead of raising a bare AttributeError when it tries to call .get() on it (Copilot review finding on PR #39, scripts/validate_chronos_carrier_fixtures.py lines ~124 and ~130).",
+  "standards_refs": [
+    "SocioProphet/socioprophet-standards-storage/docs/standards/096-multidomain-geospatial-storage-contracts.md",
+    "SocioProphet/socioprophet-standards-knowledge/docs/standards/080-multidomain-geospatial-knowledge-context.md"
+  ],
+  "claim": {
+    "claim_version": "v1",
+    "claim_id": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-02:MALFORMED",
+    "claim_type": "risk",
+    "geo_anchor": {
+      "anchor_id": "anchor:fusion:sonoma-corridor:2026-08-02",
+      "anchor_type": "bbox",
+      "bbox": [-122.75, 38.40, -122.65, 38.48],
+      "h3_cells": ["8928308280fffff", "89283082807ffff"],
+      "crs": "EPSG:4326",
+      "temporal": {
+        "observed_at": "2026-08-02T08:30:00Z",
+        "valid_from": "2026-08-02T08:00:00Z",
+        "valid_to": "2026-08-02T14:00:00Z",
+        "time_basis": "sensor_capture"
+      }
+    },
+    "source_evidence_refs": [
+      "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-02",
+      "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-02T08:00:00Z"
+    ],
+    "proposed_value": {
+      "predicate": "HighFireRisk(sonoma-corridor)",
+      "fuzzy_satisfaction_score": 0.74,
+      "risk_domain": "wildland_fire_ignition_potential",
+      "notes": "MALFORMED: fusion_rule on the explanation trace is a string, not an object."
+    },
+    "temporal_validity": {
+      "valid_from": "2026-08-02T08:00:00Z",
+      "valid_to": "2026-08-02T14:00:00Z",
+      "staleness_class": "recent"
+    },
+    "uncertainty": {
+      "confidence_score": 0.55,
+      "uncertainty_class": "high",
+      "uncertainty_notes": "MALFORMED fixture: not itself the point under test — the point under test is the shape of explanation_trace.fusion_rule.",
+      "adversarial_impact": 0.0
+    },
+    "policy_status": {
+      "status": "candidate",
+      "policy_decision_ref": "policy-decision:MALFORMED:not-reached",
+      "review_reason": "MALFORMED fixture: validator must reject before policy_status is ever inspected.",
+      "constraints": []
+    },
+    "explanation_trace_ref": "trace:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-02:MALFORMED",
+    "map_display": {
+      "show_source_attribution": true,
+      "show_uncertainty": true,
+      "show_evidence_chain": true,
+      "show_policy_status": true,
+      "display_layer": "admitted_world_state",
+      "advisory_label": "MALFORMED: fusion_rule is not an object"
+    },
+    "attribution": {
+      "primary_source_name": "Fusion: Synthetic EO vegetation-dryness scene + synthetic weather precipitation-deficit reanalysis",
+      "license_refs": ["sample-only", "copernicus-era5-sample"],
+      "attribution_texts": [
+        "EO scene: synthetic fixture for GAIA runtime validation",
+        "Weather: ERA5-like synthetic fixture for GAIA runtime validation"
+      ]
+    },
+    "provenance": {
+      "chain": ["runtime:world-claim-ltn-fusion:v0"],
+      "derived_from": [
+        "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-02",
+        "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-02T08:00:00Z"
+      ],
+      "runtime_ref": "runtime:world-claim-ltn-fusion:v0",
+      "created_at": "2026-08-02T09:00:00Z",
+      "content_hash": "sha256:fixture-placeholder-malformed"
+    },
+    "classification": {
+      "data_class": "public",
+      "handling_tags": ["demo", "fusion", "world-claim", "risk", "invalid", "negative-fixture"]
+    },
+    "chronos_grounding_status": "ungrounded",
+    "chronos_owning_authority_plane": "SocioProphet/holmes"
+  },
+  "source_evidence": [
+    {
+      "evidence_version": "v1",
+      "evidence_id": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-02",
+      "source_type": "eo_stac",
+      "source_ref": "stac:item:vegetation-dryness-scene-002",
+      "geo_anchor_ref": "anchor:fusion:sonoma-corridor:2026-08-02",
+      "content_hash": "sha256:fixture-placeholder",
+      "attribution": {
+        "source_name": "Synthetic vegetation-dryness EO fixture",
+        "license_ref": "sample-only",
+        "attribution_text": "Synthetic EO fixture for GAIA runtime validation"
+      },
+      "temporal": {
+        "observed_at": "2026-08-02T08:30:00Z",
+        "valid_from": "2026-08-02T08:25:00Z",
+        "staleness_class": "recent"
+      },
+      "confidence": {
+        "score": 0.70,
+        "confidence_class": "moderate"
+      },
+      "classification": {
+        "data_class": "public",
+        "handling_tags": ["demo", "eo", "stac", "source-evidence"]
+      }
+    },
+    {
+      "evidence_version": "v1",
+      "evidence_id": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-02T08:00:00Z",
+      "source_type": "weather_reanalysis",
+      "source_ref": "reanalysis://era5-like/sonoma-corridor/2026-08-02T08:00:00Z",
+      "geo_anchor_ref": "anchor:fusion:sonoma-corridor:2026-08-02",
+      "content_hash": "sha256:fixture-placeholder",
+      "attribution": {
+        "source_name": "ERA5-like weather reanalysis (synthetic fixture)",
+        "license_ref": "copernicus-era5-sample",
+        "attribution_text": "ERA5-like synthetic fixture for GAIA runtime validation"
+      },
+      "temporal": {
+        "observed_at": "2026-08-02T08:00:00Z",
+        "valid_from": "2026-08-02T06:00:00Z",
+        "staleness_class": "recent"
+      },
+      "confidence": {
+        "score": 0.68,
+        "confidence_class": "moderate"
+      },
+      "classification": {
+        "data_class": "public",
+        "handling_tags": ["demo", "weather", "reanalysis", "era5", "source-evidence"]
+      }
+    }
+  ],
+  "explanation_trace": {
+    "trace_version": "v1",
+    "trace_id": "trace:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-02:MALFORMED",
+    "claim_ref": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-02:MALFORMED",
+    "fusion_rule": "MALFORMED: this should be an object with rule_id/chronos_method_family/etc, not a bare string",
+    "inputs": [
+      {
+        "evidence_ref": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-02",
+        "role": "primary",
+        "weight": 0.55,
+        "confidence_at_fusion": 0.70
+      },
+      {
+        "evidence_ref": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-02T08:00:00Z",
+        "role": "corroborating",
+        "weight": 0.45,
+        "confidence_at_fusion": 0.68
+      }
+    ],
+    "uncertainty": {
+      "method": "model_calibration",
+      "combined_score": 0.55,
+      "uncertainty_class": "high"
+    },
+    "replay": {
+      "mode": "model_snapshot",
+      "command": "cat fixtures/geospatial/negative/world-claim-fusion-rule-malformed-non-object.invalid.v1.json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[\"explanation_trace\"][\"fusion_rule\"])'"
+    },
+    "provenance": {
+      "runtime_ref": "runtime:world-claim-ltn-fusion:v0",
+      "created_at": "2026-08-02T09:00:00Z",
+      "content_hash": "sha256:fixture-placeholder-malformed"
+    }
+  },
+  "invariants_violated": [
+    "explanation_trace.fusion_rule must be an object; this fixture sets it to a bare string instead.",
+    "scripts/validate_chronos_carrier_fixtures.py must reject this with a clean CheckError (e.g. 'fusion_rule must be an object, got str: ...') rather than crashing with an AttributeError from calling .get() on a non-dict (Copilot review finding on PR #39)."
+  ]
+}

--- a/fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json
+++ b/fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json
@@ -1,0 +1,189 @@
+{
+  "artifact_version": "v1",
+  "artifact_type": "gaia.world_claim.fusion",
+  "artifact_id": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01:INVALID",
+  "created_at": "2026-08-01T09:00:00Z",
+  "description": "NEGATIVE FIXTURE (must be rejected). Same LTN-style fuzzy_satisfaction_score fusion as ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json, but here the claim is incorrectly promoted to policy_status=admitted with NO chronos_non_authority_declaration on the explanation trace. This is exactly the CHRONOS negative rule this repo must keep rejecting: 'a fuzzy satisfaction score is promoted as truth' (sociosphere/docs/integration/neurosymbolic-chronos-alignment.md, 'Required negative rules' #1). scripts/validate_chronos_carrier_fixtures.py must reject this fixture.",
+  "standards_refs": [
+    "SocioProphet/socioprophet-standards-storage/docs/standards/096-multidomain-geospatial-storage-contracts.md",
+    "SocioProphet/socioprophet-standards-knowledge/docs/standards/080-multidomain-geospatial-knowledge-context.md"
+  ],
+  "claim": {
+    "claim_version": "v1",
+    "claim_id": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01:INVALID",
+    "claim_type": "risk",
+    "geo_anchor": {
+      "anchor_id": "anchor:fusion:sonoma-corridor:2026-08-01",
+      "anchor_type": "bbox",
+      "bbox": [-122.75, 38.40, -122.65, 38.48],
+      "h3_cells": ["8928308280fffff", "89283082807ffff"],
+      "crs": "EPSG:4326",
+      "temporal": {
+        "observed_at": "2026-08-01T08:30:00Z",
+        "valid_from": "2026-08-01T08:00:00Z",
+        "valid_to": "2026-08-01T14:00:00Z",
+        "time_basis": "sensor_capture"
+      }
+    },
+    "source_evidence_refs": [
+      "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+      "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z"
+    ],
+    "proposed_value": {
+      "predicate": "HighFireRisk(sonoma-corridor)",
+      "fuzzy_satisfaction_score": 0.74,
+      "risk_domain": "wildland_fire_ignition_potential",
+      "notes": "INVALID: treated as an admitted world-state fact rather than a candidate signal."
+    },
+    "temporal_validity": {
+      "valid_from": "2026-08-01T08:00:00Z",
+      "valid_to": "2026-08-01T14:00:00Z",
+      "staleness_class": "recent"
+    },
+    "uncertainty": {
+      "confidence_score": 0.55,
+      "uncertainty_class": "high",
+      "uncertainty_notes": "INVALID: high uncertainty class combined with admitted status is itself suspect, and the fuzzy_satisfaction_score is being displayed as if it were confidence/ground truth.",
+      "adversarial_impact": 0.0
+    },
+    "policy_status": {
+      "status": "admitted",
+      "policy_decision_ref": "policy-decision:INVALID:auto-admitted-without-review",
+      "review_reason": "INVALID: claim was admitted directly from the fuzzy fusion output without Holmes/Policy review and without corroborating hard evidence.",
+      "constraints": []
+    },
+    "explanation_trace_ref": "trace:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01:INVALID",
+    "map_display": {
+      "show_source_attribution": true,
+      "show_uncertainty": true,
+      "show_evidence_chain": true,
+      "show_policy_status": true,
+      "display_layer": "admitted_world_state",
+      "advisory_label": "INVALID: shown as admitted world state"
+    },
+    "attribution": {
+      "primary_source_name": "Fusion: Synthetic EO vegetation-dryness scene + synthetic weather precipitation-deficit reanalysis",
+      "license_refs": ["sample-only", "copernicus-era5-sample"],
+      "attribution_texts": [
+        "EO scene: synthetic fixture for GAIA runtime validation",
+        "Weather: ERA5-like synthetic fixture for GAIA runtime validation"
+      ]
+    },
+    "provenance": {
+      "chain": ["runtime:world-claim-ltn-fusion:v0"],
+      "derived_from": [
+        "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+        "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z"
+      ],
+      "runtime_ref": "runtime:world-claim-ltn-fusion:v0",
+      "created_at": "2026-08-01T09:00:00Z",
+      "content_hash": "sha256:fixture-placeholder-invalid"
+    },
+    "classification": {
+      "data_class": "public",
+      "handling_tags": ["demo", "fusion", "world-claim", "risk", "invalid", "negative-fixture"]
+    },
+    "chronos_grounding_status": "ungrounded",
+    "chronos_owning_authority_plane": "SocioProphet/holmes"
+  },
+  "source_evidence": [
+    {
+      "evidence_version": "v1",
+      "evidence_id": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+      "source_type": "eo_stac",
+      "source_ref": "stac:item:vegetation-dryness-scene-002",
+      "geo_anchor_ref": "anchor:fusion:sonoma-corridor:2026-08-01",
+      "content_hash": "sha256:fixture-placeholder",
+      "attribution": {
+        "source_name": "Synthetic vegetation-dryness EO fixture",
+        "license_ref": "sample-only",
+        "attribution_text": "Synthetic EO fixture for GAIA runtime validation"
+      },
+      "temporal": {
+        "observed_at": "2026-08-01T08:30:00Z",
+        "valid_from": "2026-08-01T08:25:00Z",
+        "staleness_class": "recent"
+      },
+      "confidence": {
+        "score": 0.70,
+        "confidence_class": "moderate"
+      },
+      "classification": {
+        "data_class": "public",
+        "handling_tags": ["demo", "eo", "stac", "source-evidence"]
+      }
+    },
+    {
+      "evidence_version": "v1",
+      "evidence_id": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z",
+      "source_type": "weather_reanalysis",
+      "source_ref": "reanalysis://era5-like/sonoma-corridor/2026-08-01T08:00:00Z",
+      "geo_anchor_ref": "anchor:fusion:sonoma-corridor:2026-08-01",
+      "content_hash": "sha256:fixture-placeholder",
+      "attribution": {
+        "source_name": "ERA5-like weather reanalysis (synthetic fixture)",
+        "license_ref": "copernicus-era5-sample",
+        "attribution_text": "ERA5-like synthetic fixture for GAIA runtime validation"
+      },
+      "temporal": {
+        "observed_at": "2026-08-01T08:00:00Z",
+        "valid_from": "2026-08-01T06:00:00Z",
+        "staleness_class": "recent"
+      },
+      "confidence": {
+        "score": 0.68,
+        "confidence_class": "moderate"
+      },
+      "classification": {
+        "data_class": "public",
+        "handling_tags": ["demo", "weather", "reanalysis", "era5", "source-evidence"]
+      }
+    }
+  ],
+  "explanation_trace": {
+    "trace_version": "v1",
+    "trace_id": "trace:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01:INVALID",
+    "claim_ref": "gaia:world-claim:fusion:ltn-vegetation-dryness:sonoma-corridor:2026-08-01:INVALID",
+    "fusion_rule": {
+      "rule_id": "ltn-fuzzy-high-fire-risk-v1",
+      "rule_class": "model_inference",
+      "rule_version": "v1",
+      "rule_ref": "sociosphere/docs/integration/neurosymbolic-chronos-alignment.md#method-families-and-chronos-roles",
+      "chronos_method_family": "ltn_differentiable_fuzzy_logic",
+      "chronos_method_output_type": "fuzzy_satisfaction_score"
+    },
+    "inputs": [
+      {
+        "evidence_ref": "evidence:eo_stac:vegetation-dryness-scene-002:2026-08-01",
+        "role": "primary",
+        "weight": 0.55,
+        "confidence_at_fusion": 0.70
+      },
+      {
+        "evidence_ref": "evidence:weather_reanalysis:precip-deficit-sonoma:2026-08-01T08:00:00Z",
+        "role": "corroborating",
+        "weight": 0.45,
+        "confidence_at_fusion": 0.68
+      }
+    ],
+    "uncertainty": {
+      "method": "model_calibration",
+      "combined_score": 0.55,
+      "uncertainty_class": "high"
+    },
+    "replay": {
+      "mode": "model_snapshot",
+      "command": "cat fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d[\"claim\"][\"proposed_value\"][\"fuzzy_satisfaction_score\"])'"
+    },
+    "provenance": {
+      "runtime_ref": "runtime:world-claim-ltn-fusion:v0",
+      "created_at": "2026-08-01T09:00:00Z",
+      "content_hash": "sha256:fixture-placeholder-invalid"
+    }
+  },
+  "invariants_violated": [
+    "fusion_rule.chronos_method_output_type=fuzzy_satisfaction_score requires a chronos_non_authority_declaration on the explanation trace — MISSING here.",
+    "A soft/candidate chronos_method_output_type must not carry claim.policy_status.status=admitted — this fixture sets it to 'admitted' anyway.",
+    "This is the CHRONOS negative rule 'a fuzzy satisfaction score is promoted as truth' (neurosymbolic-chronos-alignment.md, Required negative rules #1)."
+  ]
+}

--- a/fixtures/geospatial/osm-feature-world-claim.sample.v1.json
+++ b/fixtures/geospatial/osm-feature-world-claim.sample.v1.json
@@ -97,7 +97,9 @@
       "classification": {
         "data_class": "public",
         "handling_tags": ["demo", "osm", "world-claim", "proposed", "advisory"]
-      }
+      },
+      "chronos_grounding_status": "grounded",
+      "chronos_owning_authority_plane": "SocioProphet/holmes"
     }
   ],
   "evidence_records": [
@@ -163,7 +165,9 @@
         "rule_id": "single-source-passthrough-v1",
         "rule_class": "single_source_passthrough",
         "rule_version": "v1",
-        "rule_ref": "docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md#single-source-passthrough"
+        "rule_ref": "docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md#single-source-passthrough",
+        "chronos_method_family": "not_applicable",
+        "chronos_method_output_type": "hard_value"
       },
       "inputs": [
         {
@@ -230,6 +234,7 @@
     "SourceEvidence carries source_ref, temporal validity, and confidence.",
     "ExplanationTrace records the single-source passthrough rule.",
     "policy_status is 'proposed' — not admitted to world state without Holmes/Policy review.",
-    "map_display.display_layer is 'proposed_candidate' — advisory label required on /map."
+    "map_display.display_layer is 'proposed_candidate' — advisory label required on /map.",
+    "CHRONOS carrier (SocioProphet/gaia-world-model#38): chronos_method_family=not_applicable and chronos_method_output_type=hard_value for single-source passthrough — no chronos_non_authority_declaration required."
   ]
 }

--- a/geospatial/world_claim_ingest.py
+++ b/geospatial/world_claim_ingest.py
@@ -15,6 +15,15 @@ The output includes:
 A world-claim at status='proposed' must pass Holmes/Policy review before it
 may be admitted to GAIA world state or shown as truth on /map.
 
+The emitted claims/traces also carry the additive CHRONOS carrier fields
+(SocioProphet/gaia-world-model#38): fusion_rule.chronos_method_family/
+chronos_method_output_type and claim.chronos_grounding_status/
+chronos_owning_authority_plane. Single-source OSM passthrough uses no
+neuro-symbolic method, so these fields are populated at their non-authority
+defaults (chronos_method_family=not_applicable,
+chronos_method_output_type=hard_value) and no
+chronos_non_authority_declaration is required.
+
 Usage:
   python3 geospatial/world_claim_ingest.py \\
     fixtures/geospatial/osm-feature-world-claim-input.sample.v1.json \\
@@ -209,6 +218,12 @@ def build_explanation_trace(
             "rule_class": "single_source_passthrough",
             "rule_version": "v1",
             "rule_ref": "docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md#single-source-passthrough",
+            # CHRONOS carrier fields (SocioProphet/gaia-world-model#38): single-source
+            # passthrough uses no neuro-symbolic method, so no non-authority
+            # declaration is required here. See docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md
+            # for the CHRONOS carrier field mapping.
+            "chronos_method_family": "not_applicable",
+            "chronos_method_output_type": "hard_value",
         },
         "inputs": [
             {
@@ -341,6 +356,11 @@ def build_world_claim(
         },
         "classification": input_doc["classification"],
         "standards_refs": STANDARDS_REFS,
+        # CHRONOS carrier fields (SocioProphet/gaia-world-model#38). OSM geometry is
+        # taken directly from the source extract (grounded); Holmes/Policy is the
+        # owning authority plane for this claim's Verify->Govern decision.
+        "chronos_grounding_status": "grounded",
+        "chronos_owning_authority_plane": "SocioProphet/holmes",
     }
 
 

--- a/schemas/geospatial/fusion_explanation.v1.schema.json
+++ b/schemas/geospatial/fusion_explanation.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://socioprophet.org/gaia/schemas/geospatial/fusion_explanation.v1.schema.json",
   "title": "FusionExplanation v1",
-  "description": "Explanation trace for a GAIA world-claim. Records the fusion rule applied, input evidence with roles and weights, derivation steps, uncertainty derivation, and replay instructions. An ExplanationTrace is required for any world-claim that combines more than one source.",
+  "description": "Explanation trace for a GAIA world-claim. Records the fusion rule applied, input evidence with roles and weights, derivation steps, uncertainty derivation, and replay instructions. An ExplanationTrace is required for any world-claim that combines more than one source. Additive CHRONOS-carrier-compatible v1: fusion_rule.chronos_method_family/chronos_method_output_type and top-level chronos_non_authority_declaration extend this contract to satisfy sociosphere's neurosymbolic-chronos-alignment.md carrier boundary (SocioProphet/gaia-world-model#38) without changing any existing field or behavior.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -37,7 +37,42 @@
           ]
         },
         "rule_version": {"type": "string"},
-        "rule_ref": {"type": "string", "description": "URI or document reference for the rule specification."}
+        "rule_ref": {"type": "string", "description": "URI or document reference for the rule specification."},
+        "chronos_method_family": {
+          "type": "string",
+          "enum": [
+            "classical_deterministic",
+            "logic_review_formal_substrate",
+            "kautz_nsr_taxonomy_label",
+            "ltn_differentiable_fuzzy_logic",
+            "lnn_truth_bound_propagation",
+            "neurasp_neural_to_asp",
+            "satnet_differentiable_constraint",
+            "dilp_differentiable_rule_learning",
+            "deep_ontological_network_rrn",
+            "dsr_dsp_symbolic_policy",
+            "kairos_event_schema_induction",
+            "not_applicable"
+          ],
+          "default": "classical_deterministic",
+          "description": "CHRONOS carrier method-family tag (sociosphere/docs/integration/neurosymbolic-chronos-alignment.md, 'Method families and CHRONOS roles'; SocioProphet/gaia-world-model#38). Identifies which fusion/reasoning method family produced this trace, distinct from rule_class (which classifies GAIA's own fusion mechanics, e.g. weighted_mean vs bayesian_update, not neuro-symbolic technique). 'classical_deterministic' is the additive default for GAIA's existing weighted_mean/bayesian_update/ensemble_vote/threshold_gate/rule_chain/human_review rule classes when no neuro-symbolic technique was used; 'not_applicable' covers single_source_passthrough. Any other value requires chronos_non_authority_declaration on this trace."
+        },
+        "chronos_method_output_type": {
+          "type": "string",
+          "enum": [
+            "hard_value",
+            "fuzzy_satisfaction_score",
+            "truth_bound",
+            "symbolic_derivation",
+            "learned_rule_candidate",
+            "ontology_delta_candidate",
+            "policy_proposal",
+            "event_schema_candidate",
+            "not_applicable"
+          ],
+          "default": "hard_value",
+          "description": "CHRONOS carrier method output type produced by this fusion/inference step (neurosymbolic-chronos-alignment.md 'neuro-symbolic carrier boundary'). 'hard_value' is the additive default matching GAIA's existing deterministic/sensor-derived fusion outputs. Any non-'hard_value'/'not_applicable' type is a soft or candidate output per the CHRONOS negative rules (e.g. 'a fuzzy satisfaction score is promoted as truth') and MUST carry a chronos_non_authority_declaration with is_candidate_only=true on this trace; the referenced WorldClaim.policy_status.status MUST NOT be 'admitted' while that declaration holds."
+        }
       }
     },
     "inputs": {
@@ -148,6 +183,27 @@
         "runtime_ref": {"type": "string"},
         "created_at": {"type": "string", "format": "date-time"},
         "content_hash": {"type": "string"}
+      }
+    },
+    "chronos_non_authority_declaration": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["is_candidate_only", "declaration"],
+      "description": "CHRONOS carrier non-authority declaration (sociosphere/docs/integration/neurosymbolic-chronos-alignment.md 'neuro-symbolic carrier boundary' and 'Required negative rules'; SocioProphet/gaia-world-model#38). Additive field: required whenever fusion_rule.chronos_method_family is not 'classical_deterministic'/'not_applicable', or fusion_rule.chronos_method_output_type is not 'hard_value'/'not_applicable'. Absent for GAIA's existing classical fusion rules, which remain valid without it.",
+      "properties": {
+        "is_candidate_only": {
+          "type": "boolean",
+          "description": "True if this method's output must not be treated as truth, evidence, policy admission, or canonical schema/ontology authority until the owning authority plane reviews it (CHRONOS 'Required negative rules', e.g. 'a fuzzy satisfaction score is promoted as truth')."
+        },
+        "declaration": {
+          "type": "string",
+          "description": "Human-readable non-authority statement, e.g. 'LTN fuzzy satisfaction score; advisory only; not evidence, not policy admission, not canonical schema authority.'"
+        },
+        "forbidden_uses": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Specific forbidden uses for this method family, drawn from the CHRONOS method-family table's 'Forbidden use' column."
+        }
       }
     }
   }

--- a/schemas/geospatial/world_claim.v1.schema.json
+++ b/schemas/geospatial/world_claim.v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://socioprophet.org/gaia/schemas/geospatial/world_claim.v1.schema.json",
   "title": "WorldClaim v1",
-  "description": "A GAIA governed world-state claim. A claim is not admissible without anchors, source evidence, temporal validity, uncertainty, and policy status. Formal invariant: Observation/Evidence -> ProposedWorldClaim -> ExplanationTrace + Uncertainty -> PolicyDecision -> Admitted/Provisional/Review WorldClaim.",
+  "description": "A GAIA governed world-state claim. A claim is not admissible without anchors, source evidence, temporal validity, uncertainty, and policy status. Formal invariant: Observation/Evidence -> ProposedWorldClaim -> ExplanationTrace + Uncertainty -> PolicyDecision -> Admitted/Provisional/Review WorldClaim. Additive CHRONOS-carrier-compatible v1: chronos_grounding_status and chronos_owning_authority_plane extend this contract to satisfy sociosphere's neurosymbolic-chronos-alignment.md carrier boundary (SocioProphet/gaia-world-model#38) without changing any existing field or behavior.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -195,6 +195,18 @@
       "type": "array",
       "items": {"type": "string"},
       "description": "References to SocioProphet standards documents governing this claim."
+    },
+    "chronos_grounding_status": {
+      "type": "string",
+      "enum": ["grounded", "partially_grounded", "ungrounded", "unknown", "not_applicable"],
+      "default": "not_applicable",
+      "description": "CHRONOS carrier grounding status (sociosphere/docs/integration/neurosymbolic-chronos-alignment.md 'neuro-symbolic carrier boundary'; SocioProphet/gaia-world-model#38). Whether proposed_value is grounded in verifiable source evidence with anti-leakage/transduction checks (per the alignment doc's SATNet/dILP guidance), partially grounded, ungrounded, unknown, or not_applicable (e.g. simple deterministic passthrough where grounding is not the relevant frame). Additive: does not replace or duplicate uncertainty.confidence_score/uncertainty_class, which remain GAIA's existing confidence measure.",
+      "examples": ["not_applicable", "grounded", "partially_grounded", "ungrounded"]
+    },
+    "chronos_owning_authority_plane": {
+      "type": "string",
+      "description": "CHRONOS carrier owning authority plane (SocioProphet/gaia-world-model#38): names the repo/plane holding final admission authority for THIS claim's policy_status, e.g. 'SocioProphet/holmes'. Per docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md, GAIA owns Observe->Anchor->Normalize->Propose; this field records who owns the Verify->Govern decision this claim is awaiting or has received, per sociosphere's CHRONOS authority-boundary table. Additive: does not move canonical-schema authority for WorldClaim/SourceEvidence away from GAIA.",
+      "examples": ["SocioProphet/holmes"]
     }
   }
 }

--- a/scripts/validate_chronos_carrier_fixtures.py
+++ b/scripts/validate_chronos_carrier_fixtures.py
@@ -50,6 +50,7 @@ POSITIVE_FIXTURES = [
 ]
 NEGATIVE_FIXTURES = [
     "fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json",
+    "fixtures/geospatial/negative/world-claim-fusion-rule-malformed-non-object.invalid.v1.json",
 ]
 
 # chronos_method_output_type values that are soft/candidate signals per the CHRONOS
@@ -120,6 +121,11 @@ def extract_claim_trace_pairs(path: str, doc: Dict[str, Any]) -> List[Tuple[str,
 
 def check_chronos_carrier(label: str, claim: Dict[str, Any], trace: Dict[str, Any]) -> None:
     fusion_rule = trace.get("fusion_rule", {})
+    if not isinstance(fusion_rule, dict):
+        raise CheckError(
+            f"{label}: explanation_trace.fusion_rule must be an object, "
+            f"got {type(fusion_rule).__name__}: {fusion_rule!r}"
+        )
     method_family = fusion_rule.get("chronos_method_family", "classical_deterministic")
     output_type = fusion_rule.get("chronos_method_output_type", "hard_value")
 
@@ -128,6 +134,11 @@ def check_chronos_carrier(label: str, claim: Dict[str, Any], trace: Dict[str, An
     requires_declaration = is_neuro_symbolic or is_soft_output
 
     declaration = trace.get("chronos_non_authority_declaration")
+    if declaration is not None and not isinstance(declaration, dict):
+        raise CheckError(
+            f"{label}: chronos_non_authority_declaration must be an object, "
+            f"got {type(declaration).__name__}: {declaration!r}"
+        )
 
     if requires_declaration:
         if not declaration:
@@ -143,7 +154,13 @@ def check_chronos_carrier(label: str, claim: Dict[str, Any], trace: Dict[str, An
             )
         if not declaration.get("declaration"):
             raise CheckError(f"{label}: chronos_non_authority_declaration.declaration must be a non-empty string")
-        status = claim.get("policy_status", {}).get("status")
+        policy_status = claim.get("policy_status", {})
+        if not isinstance(policy_status, dict):
+            raise CheckError(
+                f"{label}: claim.policy_status must be an object, "
+                f"got {type(policy_status).__name__}: {policy_status!r}"
+            )
+        status = policy_status.get("status")
         if status == "admitted":
             raise CheckError(
                 f"{label}: a candidate-only carrier (chronos_non_authority_declaration.is_candidate_only=true) "

--- a/scripts/validate_chronos_carrier_fixtures.py
+++ b/scripts/validate_chronos_carrier_fixtures.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Validate the CHRONOS-carrier-compatible extension to WorldClaim/FusionExplanation.
+
+SocioProphet/gaia-world-model#38 (per sociosphere's
+docs/integration/neurosymbolic-chronos-alignment.md "neuro-symbolic carrier
+boundary") extends WorldClaim and FusionExplanation with additive, optional
+fields so a claim can also be expressed as a CHRONOS carrier:
+
+  - FusionExplanation.fusion_rule.chronos_method_family
+  - FusionExplanation.fusion_rule.chronos_method_output_type
+  - FusionExplanation.chronos_non_authority_declaration
+  - WorldClaim.chronos_grounding_status
+  - WorldClaim.chronos_owning_authority_plane
+
+This validator mirrors the dependency-light structural style of
+scripts/validate_contract_fixtures.py and scripts/validate_economy_fixtures.py
+and proves, without requiring an installed `jsonschema`:
+
+  - the two schemas declare the new properties (and keep them optional, so the
+    extension is additive/non-breaking for every existing fixture);
+  - positive fixtures (including classical, non-neuro-symbolic fusions that
+    don't use the new fields at all, and the new LTN-style neuro-symbolic
+    fixture that uses all of them) satisfy the CHRONOS carrier invariant;
+  - the bundled negative fixture (a fuzzy satisfaction score promoted to
+    policy_status=admitted with no non-authority declaration) is correctly
+    rejected — this is CHRONOS's "Required negative rules" #1: "a fuzzy
+    satisfaction score is promoted as truth."
+
+If `jsonschema` is installed, the claim/trace payloads are additionally
+validated against the full world_claim.v1 / fusion_explanation.v1 schemas.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+
+WORLD_CLAIM_SCHEMA = "schemas/geospatial/world_claim.v1.schema.json"
+FUSION_EXPLANATION_SCHEMA = "schemas/geospatial/fusion_explanation.v1.schema.json"
+
+# Fixtures may be a single hand-authored bundle ({"claim": {...}, "explanation_trace": {...}})
+# or a world_claim_ingest.py-style script output ({"claims": [...], "explanation_traces": [...]}).
+POSITIVE_FIXTURES = [
+    "fixtures/geospatial/osm-feature-world-claim.sample.v1.json",
+    "fixtures/geospatial/eo-osm-dem-fusion-world-claim.sample.v1.json",
+    "fixtures/geospatial/ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json",
+]
+NEGATIVE_FIXTURES = [
+    "fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json",
+]
+
+# chronos_method_output_type values that are soft/candidate signals per the CHRONOS
+# alignment doc's method-family table (never hard sensor/deterministic values).
+SOFT_OUTPUT_TYPES = {
+    "fuzzy_satisfaction_score",
+    "truth_bound",
+    "symbolic_derivation",
+    "learned_rule_candidate",
+    "ontology_delta_candidate",
+    "policy_proposal",
+    "event_schema_candidate",
+}
+# chronos_method_family values that name an actual neuro-symbolic technique
+# (as opposed to GAIA's own classical/deterministic default or not_applicable).
+NEURO_SYMBOLIC_FAMILIES = {
+    "logic_review_formal_substrate",
+    "kautz_nsr_taxonomy_label",
+    "ltn_differentiable_fuzzy_logic",
+    "lnn_truth_bound_propagation",
+    "neurasp_neural_to_asp",
+    "satnet_differentiable_constraint",
+    "dilp_differentiable_rule_learning",
+    "deep_ontological_network_rrn",
+    "dsr_dsp_symbolic_policy",
+    "kairos_event_schema_induction",
+}
+
+
+class CheckError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except FileNotFoundError:
+        fail(f"missing file: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+    if not isinstance(value, dict):
+        fail(f"expected top-level object in {path}")
+    return value
+
+
+def extract_claim_trace_pairs(path: str, doc: Dict[str, Any]) -> List[Tuple[str, Dict[str, Any], Dict[str, Any]]]:
+    """Return (label, claim, trace) tuples from either bundle shape this repo uses."""
+    pairs: List[Tuple[str, Dict[str, Any], Dict[str, Any]]] = []
+    if "claim" in doc and "explanation_trace" in doc:
+        pairs.append((path, doc["claim"], doc["explanation_trace"]))
+        return pairs
+    if "claims" in doc and "explanation_traces" in doc:
+        traces_by_id = {t["trace_id"]: t for t in doc["explanation_traces"]}
+        for claim in doc["claims"]:
+            trace_ref = claim.get("explanation_trace_ref")
+            trace = traces_by_id.get(trace_ref)
+            if trace is None:
+                raise CheckError(f"{path}: claim {claim.get('claim_id')} references missing trace {trace_ref!r}")
+            pairs.append((f"{path}:{claim.get('claim_id')}", claim, trace))
+        return pairs
+    raise CheckError(f"{path}: expected a 'claim'/'explanation_trace' bundle or 'claims'/'explanation_traces' lists")
+
+
+def check_chronos_carrier(label: str, claim: Dict[str, Any], trace: Dict[str, Any]) -> None:
+    fusion_rule = trace.get("fusion_rule", {})
+    method_family = fusion_rule.get("chronos_method_family", "classical_deterministic")
+    output_type = fusion_rule.get("chronos_method_output_type", "hard_value")
+
+    is_neuro_symbolic = method_family in NEURO_SYMBOLIC_FAMILIES
+    is_soft_output = output_type in SOFT_OUTPUT_TYPES
+    requires_declaration = is_neuro_symbolic or is_soft_output
+
+    declaration = trace.get("chronos_non_authority_declaration")
+
+    if requires_declaration:
+        if not declaration:
+            raise CheckError(
+                f"{label}: chronos_method_family={method_family!r}/chronos_method_output_type={output_type!r} "
+                "requires a chronos_non_authority_declaration on the explanation trace, but none is present "
+                "(CHRONOS negative rule: 'a fuzzy satisfaction score is promoted as truth')"
+            )
+        if declaration.get("is_candidate_only") is not True:
+            raise CheckError(
+                f"{label}: chronos_non_authority_declaration.is_candidate_only must be true when "
+                f"chronos_method_family={method_family!r}/chronos_method_output_type={output_type!r}"
+            )
+        if not declaration.get("declaration"):
+            raise CheckError(f"{label}: chronos_non_authority_declaration.declaration must be a non-empty string")
+        status = claim.get("policy_status", {}).get("status")
+        if status == "admitted":
+            raise CheckError(
+                f"{label}: a candidate-only carrier (chronos_non_authority_declaration.is_candidate_only=true) "
+                f"must not have policy_status.status=admitted, got {status!r}"
+            )
+    else:
+        # Classical/deterministic path: existing GAIA behavior must keep working
+        # unchanged whether or not a declaration happens to be present.
+        if declaration is not None and declaration.get("is_candidate_only") is False:
+            # Explicitly declaring "not candidate-only" is only meaningful alongside
+            # a neuro-symbolic method/output; on the classical path it's inert, so
+            # this is not an error — just nothing further to check.
+            pass
+
+
+def validate(path: str) -> None:
+    doc = load_json(ROOT / path)
+    for label, claim, trace in extract_claim_trace_pairs(path, doc):
+        check_chronos_carrier(label, claim, trace)
+
+
+def check_schemas_declare_new_properties() -> None:
+    world_claim_schema = load_json(ROOT / WORLD_CLAIM_SCHEMA)
+    fusion_schema = load_json(ROOT / FUSION_EXPLANATION_SCHEMA)
+
+    wc_props = world_claim_schema.get("properties", {})
+    for prop in ("chronos_grounding_status", "chronos_owning_authority_plane"):
+        if prop not in wc_props:
+            fail(f"{WORLD_CLAIM_SCHEMA}: expected additive property {prop!r} not declared")
+        if prop in world_claim_schema.get("required", []):
+            fail(f"{WORLD_CLAIM_SCHEMA}: {prop!r} must stay optional (additive extension) but is in 'required'")
+
+    fusion_rule_props = fusion_schema.get("properties", {}).get("fusion_rule", {}).get("properties", {})
+    for prop in ("chronos_method_family", "chronos_method_output_type"):
+        if prop not in fusion_rule_props:
+            fail(f"{FUSION_EXPLANATION_SCHEMA}: expected additive fusion_rule property {prop!r} not declared")
+        if prop in fusion_schema["properties"]["fusion_rule"].get("required", []):
+            fail(f"{FUSION_EXPLANATION_SCHEMA}: fusion_rule.{prop} must stay optional but is in fusion_rule 'required'")
+
+    if "chronos_non_authority_declaration" not in fusion_schema.get("properties", {}):
+        fail(f"{FUSION_EXPLANATION_SCHEMA}: expected additive property 'chronos_non_authority_declaration' not declared")
+    if "chronos_non_authority_declaration" in fusion_schema.get("required", []):
+        fail(f"{FUSION_EXPLANATION_SCHEMA}: 'chronos_non_authority_declaration' must stay optional but is in 'required'")
+
+
+def cross_validate_with_jsonschema() -> str:
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        return "skipped (jsonschema not installed)"
+
+    world_claim_validator = jsonschema.Draft202012Validator(load_json(ROOT / WORLD_CLAIM_SCHEMA))
+    fusion_validator = jsonschema.Draft202012Validator(load_json(ROOT / FUSION_EXPLANATION_SCHEMA))
+
+    checked = 0
+    for path in POSITIVE_FIXTURES:
+        doc = load_json(ROOT / path)
+        for label, claim, trace in extract_claim_trace_pairs(path, doc):
+            world_claim_validator.validate(claim)
+            fusion_validator.validate(trace)
+            checked += 1
+    return f"ok (validated {checked} claim/trace pairs against full v1 schemas)"
+
+
+def main() -> int:
+    check_schemas_declare_new_properties()
+
+    checked = 0
+    for fixture in POSITIVE_FIXTURES:
+        try:
+            validate(fixture)
+        except CheckError as exc:
+            fail(str(exc))
+        checked += 1
+
+    for fixture in NEGATIVE_FIXTURES:
+        try:
+            validate(fixture)
+        except CheckError:
+            checked += 1
+            continue
+        fail(f"negative fixture {fixture} unexpectedly passed CHRONOS carrier validation")
+
+    cross = cross_validate_with_jsonschema()
+    print(f"validated {checked} CHRONOS carrier fixture(s) (positive + negative) for WorldClaim/FusionExplanation")
+    print(f"jsonschema cross-validation: {cross}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes the gap tracked in #38: `WorldClaim`/`FusionExplanation` already matched sociosphere's CHRONOS carrier shape (`docs/integration/neurosymbolic-chronos-alignment.md`) closely, but had no field naming which fusion/reasoning method family produced a claim, and no non-authority declaration for soft/neuro-symbolic outputs.

This is a purely **additive superset extension** — no existing field, required list, or runtime behavior changed. Every fixture that validated before this PR still validates unchanged.

### New optional fields

- `FusionExplanation.fusion_rule.chronos_method_family` — e.g. `classical_deterministic` (default), `ltn_differentiable_fuzzy_logic`, `lnn_truth_bound_propagation`, `kairos_event_schema_induction`, etc. (full enum mirrors the alignment doc's method-family table)
- `FusionExplanation.fusion_rule.chronos_method_output_type` — `hard_value` (default), `fuzzy_satisfaction_score`, `truth_bound`, `symbolic_derivation`, `learned_rule_candidate`, `ontology_delta_candidate`, `policy_proposal`, `event_schema_candidate`
- `FusionExplanation.chronos_non_authority_declaration` — `{is_candidate_only, declaration, forbidden_uses}`, required whenever the two fields above name a neuro-symbolic/soft method
- `WorldClaim.chronos_grounding_status` — `grounded` / `partially_grounded` / `ungrounded` / `unknown` / `not_applicable`
- `WorldClaim.chronos_owning_authority_plane` — e.g. `SocioProphet/holmes`

### What was already covered (not duplicated)

Per the task's "map, don't duplicate" instruction, these are documented as existing mappings in `docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md` rather than given new fields:

| CHRONOS concept | GAIA field |
| --- | --- |
| Source evidence reference | `WorldClaim.source_evidence_refs` |
| Validation status / governance decision | `WorldClaim.policy_status` (GAIA's contract has Holmes do verify+govern as one step) |
| Explanation trace reference | `WorldClaim.explanation_trace_ref` |
| Replay reference | `FusionExplanation.replay` |

### Enforcement of the CHRONOS negative rule

"A fuzzy satisfaction score is promoted as truth" (alignment doc, Required negative rules #1) is now a checked invariant: any `chronos_method_output_type` in the soft-output set requires `chronos_non_authority_declaration.is_candidate_only=true`, and such a claim's `policy_status.status` must never be `admitted`.

## What's included

- Schema edits: `schemas/geospatial/world_claim.v1.schema.json`, `schemas/geospatial/fusion_explanation.v1.schema.json` (new properties only; `additionalProperties: false` unchanged everywhere)
- `geospatial/world_claim_ingest.py` now populates the new fields on GAIA's existing classical/deterministic path (`chronos_method_family=not_applicable`, `chronos_method_output_type=hard_value`) — proving the extension needs nothing extra for existing behavior
- New worked example: `fixtures/geospatial/ltn-fuzzy-vegetation-dryness-risk-world-claim.sample.v1.json` — an LTN-style fuzzy-logic fusion carrying a full non-authority declaration, correctly held at `policy_status=review`
- New negative fixture (matching this repo's `fixtures/economy/negative/`-style convention): `fixtures/geospatial/negative/world-claim-fuzzy-score-admitted-without-non-authority-declaration.invalid.v1.json` — the same fusion incorrectly marked `admitted` with no declaration; must be rejected
- Updated the two existing world-claim fixtures with the classical-path fields so they stay accurate worked examples
- `scripts/validate_chronos_carrier_fixtures.py` — new dependency-light validator (mirrors `scripts/validate_economy_fixtures.py`'s style: positive/negative fixture lists, `CheckError`/`fail`, optional `jsonschema` cross-check) confirming both schemas declare the new fields as optional, the positive fixtures pass, and the negative fixture is rejected
- Wired into `.github/workflows/contract-fixtures.yml`, which now also runs `geospatial/world_claim_ingest.py` end-to-end (it previously had no CI step at all)
- `docs/contracts/GOVERNED_WORLD_CLAIM_CONTRACT.md` gets a new "CHRONOS carrier compatibility" section with the full concept-to-field mapping table

## Non-goals honored

- No changes to GAIA's fusion/reasoning logic — this is schema/contract only
- No canonical-schema authority moved to sociosphere; GAIA keeps sole ownership of `WorldClaim`/`FusionExplanation`
- Holmes/Policy review is still required before any claim is admitted — unchanged

## Test plan

All run locally against this branch (all pass):
- [x] `python3 geospatial/world_claim_ingest.py fixtures/geospatial/osm-feature-world-claim-input.sample.v1.json /tmp/out.json` — existing script output now also carries the new CHRONOS fields at their non-authority defaults
- [x] `python3 scripts/validate_chronos_carrier_fixtures.py` — new validator; positive fixtures pass, negative fixture correctly rejected, optional `jsonschema` cross-check passes
- [x] `python3 scripts/validate_contract_fixtures.py`
- [x] `python3 scripts/validate_multidomain_fixtures.py`
- [x] `python3 scripts/validate_bounded_osm_source_adapter.py`
- [x] `python3 scripts/validate_repo.py`
- [x] `python3 scripts/validate_economy_fixtures.py` (pre-existing, unaffected — confirms no cross-domain regression)
- [x] All other `contract-fixtures.yml` steps (ofif bridge, soil fusion, control tower anomaly, osm ingest/tile/route-graph, lidar extract/rollback) re-run manually with no regressions

Refs #38.