### PR TITLE
feat(economy): economic spine as the world-model value-flow subsystem (ADR-0003 + VFS contract with teeth)

### DIFF
--- a/.github/workflows/value-flow-subsystem.yml
+++ b/.github/workflows/value-flow-subsystem.yml
@@ -5,7 +5,11 @@ on:
     paths:
       - 'schemas/economy/value_flow_binding.v1.schema.json'
       - 'schemas/economy/twin_scale_transfer.v1.schema.json'
+      - 'schemas/economy/twin_hierarchy_composition.v1.schema.json'
+      - 'schemas/biosphere/**'
       - 'examples/economy/value_flow/**'
+      - 'examples/biosphere/**'
+      - 'gaia/twins/composition.v1.json'
       - 'scripts/validate_value_flow_subsystem.py'
       - 'docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md'
       - 'docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md'
@@ -14,7 +18,11 @@ on:
     paths:
       - 'schemas/economy/value_flow_binding.v1.schema.json'
       - 'schemas/economy/twin_scale_transfer.v1.schema.json'
+      - 'schemas/economy/twin_hierarchy_composition.v1.schema.json'
+      - 'schemas/biosphere/**'
       - 'examples/economy/value_flow/**'
+      - 'examples/biosphere/**'
+      - 'gaia/twins/composition.v1.json'
       - 'scripts/validate_value_flow_subsystem.py'
       - 'docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md'
       - 'docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md'

--- a/.github/workflows/value-flow-subsystem.yml
+++ b/.github/workflows/value-flow-subsystem.yml
@@ -1,0 +1,37 @@
+name: Value-Flow Subsystem Contract
+
+on:
+  push:
+    paths:
+      - 'schemas/economy/value_flow_binding.v1.schema.json'
+      - 'schemas/economy/twin_scale_transfer.v1.schema.json'
+      - 'examples/economy/value_flow/**'
+      - 'scripts/validate_value_flow_subsystem.py'
+      - 'docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md'
+      - 'docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md'
+      - '.github/workflows/value-flow-subsystem.yml'
+  pull_request:
+    paths:
+      - 'schemas/economy/value_flow_binding.v1.schema.json'
+      - 'schemas/economy/twin_scale_transfer.v1.schema.json'
+      - 'examples/economy/value_flow/**'
+      - 'scripts/validate_value_flow_subsystem.py'
+      - 'docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md'
+      - 'docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md'
+      - '.github/workflows/value-flow-subsystem.yml'
+
+jobs:
+  validate-value-flow-subsystem:
+    name: Validate value-flow subsystem contract (teeth both directions)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run value-flow subsystem contract validator
+        run: python3 scripts/validate_value_flow_subsystem.py

--- a/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
+++ b/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
@@ -118,8 +118,11 @@ Jacob's-ladder ecosystem / natural-capital assets bind to the GAIA biosphere sta
 
 ## Consumed soft-refs (by reference, never vendored)
 
-- `SocioProphet/economic-prophet@feat/welfare-annealing` — carrying-capacity discount,
-  QoL welfare objective (forward soft-ref; the branch's files are never edited here).
+- `SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583` — the
+  welfare-annealing dynamics (WEA-1), merged to main: carrying-capacity discount, QoL
+  welfare objective, and `welfare_annealing/gaia_binding.py`, which emits the
+  `value_flow_binding.v1` / `twin_scale_transfer.v1` records this contract governs
+  (pinned soft-ref; its files are never edited here).
 - `SocioProphet/economic-prophet` `asset_ladder` (ALC-1) — the rung ontology
   (`natural_capital` / `extractive_nonrenewable` / `renewable_harvest`).
 - `SocioProphet/economic-prophet` `risk_measures` — expected-shortfall tail measure.

--- a/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
+++ b/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
@@ -1,0 +1,112 @@
+# GAIA Value-Flow Subsystem Contract
+
+Status: v1 (binding, with teeth)
+Date: 2026-08-03
+Decision: [ADR-0003](../decisions/ADR-0003-economic-spine-value-flow-subsystem.md)
+
+## Scope
+
+This contract binds the estate's **economic spine** (Economic Prophet omnirisk/EP + the
+in-flight welfare-annealing dynamics) UPWARD into the **GAIA world model** as its
+**value-flow subsystem**, and places it in the digital-twin hierarchy. It does not
+redefine value (UVMC/EP remains the additive measure). It declares what the spine must
+READ from the world-model substrate *W*, and enforces it with teeth in both directions.
+
+Consume-not-fork: economic-prophet kernels and the welfare-annealing branch are
+referenced by pinned ref; nothing is vendored. The contract validates static fixtures
+only — no live or shared-state read/write.
+
+## Objects
+
+| Object | Schema | Purpose |
+| --- | --- | --- |
+| `ValueFlowSubsystemBinding` | `schemas/economy/value_flow_binding.v1.schema.json` | A welfare/EP run's declaration of how its carrying-capacity, ecosystem assets, and QoL objective READ from *W*. |
+| `TwinScaleValueTransfer` | `schemas/economy/twin_scale_transfer.v1.schema.json` | A value flow across an adjacent boundary of the twin hierarchy, carrying the IC-1 conservation rule. |
+
+## The twin hierarchy
+
+```
+galactic_space_twin  ⟷  world_economic_twin (this spine)  ⟷  human_digital_twin
+        (SpaceTwin.vue / 5D cube)   (economic-prophet)         (prophet-health / gaia twins)
+```
+
+Value flows are the exchange dynamics across this stack. Every `TwinScaleValueTransfer`
+declares the full `scale_stack` and moves value between two adjacent scales.
+
+## The four bindings and their teeth
+
+A control that never fires is suspect. Each tooth is exercised in BOTH directions by the
+committed fixtures under `examples/economy/value_flow/`: at least one admitted fixture
+where the tooth stays silent, and at least one fixture where it fires.
+
+### Binding 1 — Carrying-capacity ⟷ Gaia biosphere
+
+The welfare-annealing carrying-capacity discount and the Jacob's-ladder natural-capital /
+renewable base MUST be a READ of the GAIA biosphere/resource state
+(`carrying_capacity.source.kind == "world_model_read"` with a resolvable `read_ref`).
+
+- **`T1-CONST` → REJECT.** A binding whose carrying-capacity source is `constant` is a
+  hardcoded free parameter — the free-parameter smell — and is rejected.
+- **`T1-RESERVE` → FLAG.** A value-flow that draws a non-renewable stock below the
+  world-model's declared reserve floor (`current − non_renewable_draw < reserve.floor`)
+  is flagged as a planetary-boundary breach — the "paper-inductance false-growth"
+  analog: growth booked against a stock the world model says isn't there. The run is
+  admitted **with a flag** (the flag is the receipt), not rejected.
+
+### Binding 2 — Twin-hierarchy composition + value conservation (IC-1)
+
+The scale stack is declared explicitly and value flows are its exchange dynamics.
+
+- **`T2-CONSERVE` → REJECT.** Value is conserved across a twin-scale aggregation:
+  `parent.value == Σ children + Σ declared_sinks − Σ declared_sources` (within
+  `conservation.tolerance`). A cross-scale flow that creates value out of nothing —
+  children exceeding the parent with no receipted source — is rejected. Injections and
+  removals are legal only when receipted as `declared_sources` / `declared_sinks`.
+
+### Binding 3 — QoL ⟷ human digital twin
+
+The welfare objective's life-length / health / education dimensions MUST AGGREGATE from
+human-digital-twin state (population = Σ twins). Each dimension carries
+`derivation.kind == "twin_aggregate"` and a `from_twin_dimension` reference into
+`gaia/twins/human/**`.
+
+- **`T3-QOL` → REJECT.** A population QoL index with any `exogenous` dimension, or a
+  `twin_aggregate` dimension missing its `from_twin_dimension`, is not derivable from
+  its constituent human twins and is rejected.
+
+### Binding 4 — Ecosystem assets ⟷ biosphere
+
+Jacob's-ladder ecosystem / natural-capital assets bind to the GAIA biosphere state
+(`biosphere_ref`); renewable regeneration rate is a world-model read.
+
+- **`T4-REGEN` → REJECT.** A `renewable_harvest` rung whose `regeneration.source.kind`
+  is `constant` (or `none`) instead of `world_model_read` is rejected. Depleting rungs
+  (`natural_capital`, `extractive_nonrenewable`) may carry `none`.
+
+## Verdict semantics
+
+| Decision | Meaning |
+| --- | --- |
+| `admit` | Binding/transfer reads from *W* and conserves value; no tooth fired. |
+| `admit_with_flag` | Admissible, but a planetary-boundary breach is receipted (`T1-RESERVE`). |
+| `reject` | A tooth fired; the run is not admissible as a value-flow subsystem run. |
+
+## Consumed soft-refs (by reference, never vendored)
+
+- `SocioProphet/economic-prophet@feat/welfare-annealing` — carrying-capacity discount,
+  QoL welfare objective (forward soft-ref; the branch's files are never edited here).
+- `SocioProphet/economic-prophet` `asset_ladder` (ALC-1) — the rung ontology
+  (`natural_capital` / `extractive_nonrenewable` / `renewable_harvest`).
+- `SocioProphet/economic-prophet` `risk_measures` — expected-shortfall tail measure.
+- `gaia/twins/human/twin-schema.json` — human-digital-twin state dimensions.
+- `schemas/economy/economy_observation.v1.schema.json` — the pre-existing GAIA↔EP
+  observation soft-ref this contract composes with.
+- Ontogenesis / Systema Concept Entry (sibling agent) — governs the vocabulary; this
+  contract references governed concepts, it does not duplicate them.
+
+## Enforcement
+
+`scripts/validate_value_flow_subsystem.py` (deterministic, Python stdlib only) judges
+every fixture, asserts each fixture's `_expected` verdict and tooth, and fails if any
+declared tooth is never exercised in the firing direction. Wired into CI by
+`.github/workflows/value-flow-subsystem.yml`.

--- a/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
+++ b/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
@@ -108,12 +108,25 @@ Jacob's-ladder ecosystem / natural-capital assets bind to the GAIA biosphere sta
 - **`T5-RESOLVE`** (above) also applies: a renewable regeneration `read_ref` must
   resolve to a declared `BiosphereState` regeneration entry.
 
+### Concept governance — vocabulary binds to governed concepts (ontogenesis#141)
+
+Every governed bare enum (`carrying_capacity`, the three rungs, `qol_index` + its
+`life_length` / `health` / `education` dimensions, and the three twin-scale terms) carries
+a `concept_ref` — the Systema Concept Entry ID registered in **ontogenesis#141** (registry
+`Platform/Systema/`, `systema:concept:*`). The 11 governed IDs are the authority; this
+contract references them, it does not define vocabulary.
+
+- **`T7-CONCEPT` → FLAG.** A governed bare enum used **without** its `concept_ref` (where
+  one of the 11 exists) is flagged — prefer-governed-ID (the transition nudge).
+- **`T7-CONCEPT` → REJECT.** A `concept_ref` that is **not** one of the 11 governed IDs,
+  or is the **wrong** governed concept for its enum, is rejected.
+
 ## Verdict semantics
 
 | Decision | Meaning |
 | --- | --- |
-| `admit` | Binding/transfer reads from *W* and conserves value; no tooth fired. |
-| `admit_with_flag` | Admissible, but a planetary-boundary breach is receipted (`T1-RESERVE`). |
+| `admit` | Binding/transfer reads from *W*, conserves value, and its governed vocabulary carries correct `concept_ref`s; no tooth fired. |
+| `admit_with_flag` | Admissible, but a receipt is raised: a planetary-boundary breach (`T1-RESERVE`) or a missing-but-governable `concept_ref` (`T7-CONCEPT`). |
 | `reject` | A tooth fired; the run is not admissible as a value-flow subsystem run. |
 
 ## Consumed soft-refs (by reference, never vendored)
@@ -130,21 +143,31 @@ Jacob's-ladder ecosystem / natural-capital assets bind to the GAIA biosphere sta
 - `schemas/economy/economy_observation.v1.schema.json` — the pre-existing GAIA↔EP
   observation soft-ref this contract composes with.
 
-## Cross-references — ontogenesis concept governance (sibling agent)
+## Cross-references — ontogenesis concept governance (sibling agent), ENFORCED
 
 The vocabulary this contract uses is governed by the ontogenesis / **Systema Concept
-Entry** concept lifecycle, owned by the sibling integration agent, which is registering:
-`carrying_capacity`, `natural_capital`, `extractive_nonrenewable`, `renewable_harvest`,
-`qol_index` (its `life_length` / `health` / `education` dimensions), and the three
-twin-scale terms `galactic_space_twin` / `world_economic_twin` / `human_digital_twin`.
-This contract **references** those governed concepts; it does not duplicate them.
+Entry** concept lifecycle, owned by the sibling integration agent. The governed IDs are
+**merged in ontogenesis#141** (registry `Platform/Systema/`, resolve against
+`systema:concept:*`). This contract **references** those governed concepts by
+`concept_ref`; it does not duplicate them. The 11 governed IDs:
 
-- Today these are carried as bare enum strings in the schemas above.
-- **Follow-up tooth `T7-CONCEPT` (documented, not yet enforced).** Once the ontogenesis
-  concept-governance PR lands and provides stable concept IDs, add a tooth that REJECTS a
-  binding/transfer whose vocabulary terms do not resolve to a governed Systema Concept
-  Entry ID — swapping bare-string → concept-ID. Held open pending the relayed concept IDs
-  (see the filed follow-up for @mdheller).
+| Bare enum | Governed Systema Concept Entry ID |
+| --- | --- |
+| `carrying_capacity` | `systema:concept:carrying-capacity` |
+| `natural_capital` | `systema:concept:natural-capital` |
+| `extractive_nonrenewable` | `systema:concept:extractive-nonrenewable` |
+| `renewable_harvest` | `systema:concept:renewable-harvest` |
+| `qol_index` | `systema:concept:qol-index` |
+| `qol_index.life_length` | `systema:concept:qol-dim-life-length` |
+| `qol_index.health` | `systema:concept:qol-dim-health` |
+| `qol_index.education` | `systema:concept:qol-dim-education` |
+| `galactic_space_twin` | `systema:concept:galactic-space-twin` |
+| `world_economic_twin` | `systema:concept:world-economic-twin` |
+| `human_digital_twin` | `systema:concept:human-digital-twin` |
+
+Enforced by tooth `T7-CONCEPT` (above): the `concept_ref` sits beside each governed bare
+enum in `value_flow_binding.v1` / `twin_scale_transfer.v1` and the composition record;
+missing-but-governable is flagged, ungoverned/wrong is rejected.
 
 ## Enforcement
 

--- a/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
+++ b/docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md
@@ -22,6 +22,21 @@ only — no live or shared-state read/write.
 | --- | --- | --- |
 | `ValueFlowSubsystemBinding` | `schemas/economy/value_flow_binding.v1.schema.json` | A welfare/EP run's declaration of how its carrying-capacity, ecosystem assets, and QoL objective READ from *W*. |
 | `TwinScaleValueTransfer` | `schemas/economy/twin_scale_transfer.v1.schema.json` | A value flow across an adjacent boundary of the twin hierarchy, carrying the IC-1 conservation rule. |
+| `BiosphereState` | `schemas/biosphere/biosphere_state.v1.schema.json` | A declared snapshot of substrate-*W* biosphere/resource state (carrying-capacity index, reserves + floors, regeneration rates, planetary boundaries). The **resolution target** for a binding's `world_model_read` refs. Fixtures under `examples/biosphere/**`. |
+| `TwinHierarchyComposition` | `schemas/economy/twin_hierarchy_composition.v1.schema.json` | The first-class declaration of the twin hierarchy (`gaia/twins/composition.v1.json`): ordered stack + explicit parent/child scale edges. The authority a transfer's `scale_stack` and parent/child scales must be consistent with. |
+
+## Resolution — reads must point at something
+
+A `world_model_read` is not a claim, it is a **resolvable reference**. Every `read_ref` a
+binding declares (carrying-capacity, renewable regeneration, reserve floor) MUST resolve
+to a declared `BiosphereState` entry — a canonical `gaia://biosphere/<path>@<as_of>`
+reference answered by `examples/biosphere/**`. This is what makes `T1-CONST` /
+`T1-RESERVE` / `T4-REGEN` load-bearing: a source may not merely *declare*
+`kind: world_model_read`, its ref must land on substrate-*W* state that actually exists
+at that `@<as_of>` (see tooth `T5-RESOLVE`).
+
+Likewise the twin hierarchy is not an ad-hoc array: every `TwinScaleValueTransfer` is
+checked against the declared `TwinHierarchyComposition` record (see tooth `T6-COMPOSE`).
 
 ## The twin hierarchy
 
@@ -52,16 +67,24 @@ renewable base MUST be a READ of the GAIA biosphere/resource state
   is flagged as a planetary-boundary breach — the "paper-inductance false-growth"
   analog: growth booked against a stock the world model says isn't there. The run is
   admitted **with a flag** (the flag is the receipt), not rejected.
+- **`T5-RESOLVE` → REJECT.** A carrying-capacity / regeneration / reserve `read_ref`
+  that does not resolve to a declared `BiosphereState` entry is a read pointing at
+  nothing, and is rejected.
 
 ### Binding 2 — Twin-hierarchy composition + value conservation (IC-1)
 
-The scale stack is declared explicitly and value flows are its exchange dynamics.
+The scale stack is declared explicitly, backed by a first-class `TwinHierarchyComposition`
+record, and value flows are its exchange dynamics.
 
 - **`T2-CONSERVE` → REJECT.** Value is conserved across a twin-scale aggregation:
   `parent.value == Σ children + Σ declared_sinks − Σ declared_sources` (within
   `conservation.tolerance`). A cross-scale flow that creates value out of nothing —
   children exceeding the parent with no receipted source — is rejected. Injections and
   removals are legal only when receipted as `declared_sources` / `declared_sinks`.
+- **`T6-COMPOSE` → REJECT.** A transfer whose `scale_stack` is not the declared
+  `ordered_stack`, or whose parent→child scales are not an adjacent parent→child edge in
+  the composition record, is rejected (e.g. a galactic→human transfer that skips the
+  world-economic scale).
 
 ### Binding 3 — QoL ⟷ human digital twin
 
@@ -82,6 +105,8 @@ Jacob's-ladder ecosystem / natural-capital assets bind to the GAIA biosphere sta
 - **`T4-REGEN` → REJECT.** A `renewable_harvest` rung whose `regeneration.source.kind`
   is `constant` (or `none`) instead of `world_model_read` is rejected. Depleting rungs
   (`natural_capital`, `extractive_nonrenewable`) may carry `none`.
+- **`T5-RESOLVE`** (above) also applies: a renewable regeneration `read_ref` must
+  resolve to a declared `BiosphereState` regeneration entry.
 
 ## Verdict semantics
 
@@ -101,12 +126,28 @@ Jacob's-ladder ecosystem / natural-capital assets bind to the GAIA biosphere sta
 - `gaia/twins/human/twin-schema.json` — human-digital-twin state dimensions.
 - `schemas/economy/economy_observation.v1.schema.json` — the pre-existing GAIA↔EP
   observation soft-ref this contract composes with.
-- Ontogenesis / Systema Concept Entry (sibling agent) — governs the vocabulary; this
-  contract references governed concepts, it does not duplicate them.
+
+## Cross-references — ontogenesis concept governance (sibling agent)
+
+The vocabulary this contract uses is governed by the ontogenesis / **Systema Concept
+Entry** concept lifecycle, owned by the sibling integration agent, which is registering:
+`carrying_capacity`, `natural_capital`, `extractive_nonrenewable`, `renewable_harvest`,
+`qol_index` (its `life_length` / `health` / `education` dimensions), and the three
+twin-scale terms `galactic_space_twin` / `world_economic_twin` / `human_digital_twin`.
+This contract **references** those governed concepts; it does not duplicate them.
+
+- Today these are carried as bare enum strings in the schemas above.
+- **Follow-up tooth `T7-CONCEPT` (documented, not yet enforced).** Once the ontogenesis
+  concept-governance PR lands and provides stable concept IDs, add a tooth that REJECTS a
+  binding/transfer whose vocabulary terms do not resolve to a governed Systema Concept
+  Entry ID — swapping bare-string → concept-ID. Held open pending the relayed concept IDs
+  (see the filed follow-up for @mdheller).
 
 ## Enforcement
 
-`scripts/validate_value_flow_subsystem.py` (deterministic, Python stdlib only) judges
-every fixture, asserts each fixture's `_expected` verdict and tooth, and fails if any
-declared tooth is never exercised in the firing direction. Wired into CI by
+`scripts/validate_value_flow_subsystem.py` (deterministic, Python stdlib only) loads the
+declared `BiosphereState` (`examples/biosphere/**`) and `TwinHierarchyComposition`
+(`gaia/twins/composition.v1.json`), judges every fixture, asserts each fixture's
+`_expected` verdict and tooth, and fails if any declared tooth is never exercised in the
+firing direction (no dead teeth). Wired into CI by
 `.github/workflows/value-flow-subsystem.yml`.

--- a/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
+++ b/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
@@ -75,9 +75,18 @@ Home rationale — **gaia-world-model, not economic-prophet**:
 | `T2-CONSERVE` | 2 | a cross-scale flow creates value out of nothing (`parent ≠ Σchildren + Σsinks − Σsources`) | REJECT |
 | `T3-QOL` | 3 | a population QoL dimension is not derivable from human-twin dimensions | REJECT (exogenous-QoL smell) |
 | `T4-REGEN` | 4 | a renewable-harvest regeneration rate is a constant, not a world-model read | REJECT |
+| `T5-RESOLVE` | 1 / 4 | a `world_model_read` `read_ref` does not resolve to a declared biosphere-state entry | REJECT (a read pointing at nothing) |
+| `T6-COMPOSE` | 2 | a transfer's `scale_stack` / parent→child scales are inconsistent with the declared twin-hierarchy composition | REJECT |
 
-The checker also fails CI if any declared tooth is **never** exercised in the firing
-direction (no dead teeth), and asserts the admitted fixtures fire **no** tooth.
+`T5-RESOLVE` is what makes `T1-CONST` / `T1-RESERVE` / `T4-REGEN` load-bearing: a source
+may not merely *claim* to be a world-model read — its ref must resolve to declared
+substrate-*W* biosphere state at that `@<as_of>`. The checker also fails CI if any
+declared tooth is **never** exercised in the firing direction (no dead teeth), and
+asserts the admitted fixtures fire **no** tooth.
+
+A follow-up tooth `T7-CONCEPT` is documented (not yet enforced): once the ontogenesis
+concept-governance PR provides stable Systema Concept Entry IDs, reject vocabulary terms
+that do not resolve to a governed concept ID (bare-string → concept-ID).
 
 ## Consequences
 
@@ -103,8 +112,12 @@ direction (no dead teeth), and asserts the admitted fixtures fire **no** tooth.
 - `docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md`
 - `schemas/economy/value_flow_binding.v1.schema.json`
 - `schemas/economy/twin_scale_transfer.v1.schema.json`
+- `schemas/biosphere/biosphere_state.v1.schema.json` (the substrate-*W* resolution target)
+- `schemas/economy/twin_hierarchy_composition.v1.schema.json`
 - `examples/economy/value_flow/**` (valid + invalid + flag fixtures, one per tooth,
   both directions)
+- `examples/biosphere/**` (declared biosphere/resource state the reads resolve to)
+- `gaia/twins/composition.v1.json` (the first-class twin-hierarchy composition record)
 - `scripts/validate_value_flow_subsystem.py` (deterministic, stdlib only)
 - `.github/workflows/value-flow-subsystem.yml`
 

--- a/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
+++ b/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
@@ -15,10 +15,12 @@ The estate has two mature planes that were never bound to each other:
   provenance home for those layers.
 - **The economic spine (Economic Prophet).** `SocioProphet/economic-prophet` is the
   value engine. Its omnirisk/EP kernels are merged on `main`
-  (`risk_measures`, `ftp`, `term_calculus`, `asset_ladder`, `flow_regime`); the
-  **welfare-annealing** dynamics — carrying-capacity discount, the Jacob's-ladder
-  natural-capital / renewable base, and the QoL welfare objective — are in flight on
-  `economic-prophet@feat/welfare-annealing`.
+  (`risk_measures`, `ftp`, `term_calculus`, `asset_ladder`, `flow_regime`), and the
+  **welfare-annealing** dynamics (WEA-1) — carrying-capacity discount, the Jacob's-ladder
+  natural-capital / renewable base, and the QoL welfare objective — are now **merged to
+  `main`** at `economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583` (module
+  `src/open_ep_framework/welfare_annealing/`), including `gaia_binding.py`, which emits
+  the `value_flow_binding.v1` and `twin_scale_transfer.v1` records this contract governs.
 
 `schemas/economy/economy_observation.v1.schema.json` already binds GAIA to Economic
 Prophet by soft-ref for a *single observation* (`framework_ref:
@@ -95,7 +97,8 @@ that do not resolve to a governed concept ID (bare-string → concept-ID).
 - GAIA remains the semantic/provenance home; EP remains the value engine. Neither is
   forked into the other.
 - The welfare-annealing files are **not edited** by this ADR; they are consumed by
-  branch-ref as a forward soft-ref.
+  pinned soft-ref (`@a51a23f52dfe7b0e984a42a19a762dabe714a583`, merged to
+  economic-prophet main), never vendored.
 
 ## Non-goals
 
@@ -129,6 +132,8 @@ that do not resolve to a governed concept ID (bare-string → concept-ID).
   governed concepts and does not duplicate them; the terms should resolve against the
   ontogenesis concept-governance PR once landed.
 - **economic-prophet**: `asset_ladder` (ALC-1) rung ontology; `risk_measures`
-  (expected-shortfall) tail measure; `feat/welfare-annealing` dynamics.
+  (expected-shortfall) tail measure; welfare-annealing (WEA-1) dynamics +
+  `welfare_annealing/gaia_binding.py` emitter, merged to main at
+  `@a51a23f52dfe7b0e984a42a19a762dabe714a583`.
 - **prophet-workspace** ADR-0003 (RCS/4D) — the WorldModelSubstrate *W* naming.
 - ADR-0002 — GAIA as the home for world-model layer contracts.

--- a/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
+++ b/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
@@ -1,0 +1,121 @@
+# ADR-0003: The Economic Spine is the Value-Flow Subsystem of the World Model
+
+Status: Proposed
+Date: 2026-08-03
+
+## Context
+
+The estate has two mature planes that were never bound to each other:
+
+- **The world model (GAIA).** GAIA owns the WorldModelSubstrate *W*: geospatial
+  substrate, ontology, evidence graph, biosphere / resource / carrying-capacity state,
+  simulation, and the digital-twin hierarchy (`gaia/twins/**`). ADR-0002 established
+  that world-model layers land here as contracts, schemas, examples, and validation
+  hooks rather than as new repositories, and that GAIA remains the semantic and
+  provenance home for those layers.
+- **The economic spine (Economic Prophet).** `SocioProphet/economic-prophet` is the
+  value engine. Its omnirisk/EP kernels are merged on `main`
+  (`risk_measures`, `ftp`, `term_calculus`, `asset_ladder`, `flow_regime`); the
+  **welfare-annealing** dynamics — carrying-capacity discount, the Jacob's-ladder
+  natural-capital / renewable base, and the QoL welfare objective — are in flight on
+  `economic-prophet@feat/welfare-annealing`.
+
+`schemas/economy/economy_observation.v1.schema.json` already binds GAIA to Economic
+Prophet by soft-ref for a *single observation* (`framework_ref:
+SocioProphet/economic-prophet@<sha>`, EP as the canonical additive value measure). What
+was missing is the **composition**: the economic spine as a *subsystem of the world
+model*, placed in the twin hierarchy, with value flows as the exchange dynamics — and,
+critically, with its ecological and human terms bound to world-model state **by
+reference** rather than left as free parameters.
+
+The failure mode being closed is a welfare/EP run whose carrying-capacity term is a
+hand-picked constant, whose QoL objective is exogenous, and whose cross-scale value
+flows create value out of nothing. That is the economic analog of GAIA's
+"map-label-as-truth": numbers that *look* governed but read from nowhere.
+
+## Decision
+
+Establish the economic spine as the **value-flow subsystem of the world model**, and
+place it in the twin hierarchy, as a **binding contract with teeth** landed in
+`gaia-world-model` (consistent with ADR-0002). GAIA declares what the spine must READ
+from *W*; the teeth reject spine runs that do not.
+
+Home rationale — **gaia-world-model, not economic-prophet**:
+
+1. The binding is *upward*: the world model owns the biosphere/resource state and the
+   twin hierarchy that the spine READS. The contract is a world-model boundary
+   contract; EP owns its own internal contracts (ALC-1, RFL-1, FRT-1, …).
+2. ADR-0002 already names GAIA the home for world-model layer/composition contracts and
+   forbids spinning up a new repo for them.
+3. `schemas/economy/**` is the established soft-ref surface between the two planes.
+4. Consume-not-fork: EP kernels and the welfare-annealing branch are referenced by
+   pinned ref; nothing is vendored.
+
+### The four bindings
+
+1. **Carrying-capacity ⟷ Gaia biosphere.** The welfare-annealing carrying-capacity
+   discount and the Jacob's-ladder natural-capital / renewable base are a READ of the
+   GAIA biosphere/resource state, not a free parameter.
+2. **Twin-hierarchy composition + value conservation.** The scale stack is
+   `galactic_space_twin ⟷ world_economic_twin (this spine) ⟷ human_digital_twin`, with
+   value flows as the cross-scale exchange dynamics. Value is conserved across a
+   twin-scale aggregation (IC-1).
+3. **QoL ⟷ human digital twin.** The welfare objective's life-length / health /
+   education dimensions AGGREGATE from human-digital-twin state (population = Σ twins),
+   not exogenous.
+4. **Ecosystem assets ⟷ biosphere.** Jacob's-ladder ecosystem / natural-capital assets
+   bind to the GAIA biosphere state; renewable regeneration rate is a world-model read.
+
+### Teeth (both directions — a control that never fires is suspect)
+
+| Tooth | Binding | Fires when | Verdict |
+| --- | --- | --- | --- |
+| `T1-CONST` | 1 | carrying-capacity source is a hardcoded constant, not a world-model read | REJECT (free-parameter smell) |
+| `T1-RESERVE` | 1 / 4 | a non-renewable draw takes a stock below the world-model's declared reserve floor | FLAG (planetary-boundary breach; the paper-inductance false-growth analog) |
+| `T2-CONSERVE` | 2 | a cross-scale flow creates value out of nothing (`parent ≠ Σchildren + Σsinks − Σsources`) | REJECT |
+| `T3-QOL` | 3 | a population QoL dimension is not derivable from human-twin dimensions | REJECT (exogenous-QoL smell) |
+| `T4-REGEN` | 4 | a renewable-harvest regeneration rate is a constant, not a world-model read | REJECT |
+
+The checker also fails CI if any declared tooth is **never** exercised in the firing
+direction (no dead teeth), and asserts the admitted fixtures fire **no** tooth.
+
+## Consequences
+
+- The economic spine acquires a machine-checkable place in the world model: a
+  value-flow run is admissible only if its ecological and human terms READ from *W*.
+- GAIA remains the semantic/provenance home; EP remains the value engine. Neither is
+  forked into the other.
+- The welfare-annealing files are **not edited** by this ADR; they are consumed by
+  branch-ref as a forward soft-ref.
+
+## Non-goals
+
+- No new repository is created.
+- No welfare-annealing source file is modified; no economic-prophet code is vendored.
+- No live/shared-state read or write is performed; the contract validates static
+  fixtures only.
+- This ADR does not redefine value (UVMC/EP remains the additive measure) and does not
+  claim GAIA is a complete Earth simulator.
+
+## Initial implementation package
+
+- `docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md` (this file)
+- `docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md`
+- `schemas/economy/value_flow_binding.v1.schema.json`
+- `schemas/economy/twin_scale_transfer.v1.schema.json`
+- `examples/economy/value_flow/**` (valid + invalid + flag fixtures, one per tooth,
+  both directions)
+- `scripts/validate_value_flow_subsystem.py` (deterministic, stdlib only)
+- `.github/workflows/value-flow-subsystem.yml`
+
+## Cross-references
+
+- **Ontogenesis (sibling agent).** The concept lifecycle / Systema Concept Entry
+  governs the *vocabulary* used here (`carrying_capacity`, `natural_capital`,
+  `renewable_harvest`, `qol_index`, twin-scale terms). This ADR *references* those
+  governed concepts and does not duplicate them; the terms should resolve against the
+  ontogenesis concept-governance PR once landed.
+- **economic-prophet**: `asset_ladder` (ALC-1) rung ontology; `risk_measures`
+  (expected-shortfall) tail measure; `feat/welfare-annealing` dynamics.
+- **prophet-workspace** ADR-0003 (RCS/4D) — the WorldModelSubstrate *W* naming.
+- ADR-0002 — GAIA as the home for world-model layer contracts.

--- a/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
+++ b/docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md
@@ -79,6 +79,8 @@ Home rationale — **gaia-world-model, not economic-prophet**:
 | `T4-REGEN` | 4 | a renewable-harvest regeneration rate is a constant, not a world-model read | REJECT |
 | `T5-RESOLVE` | 1 / 4 | a `world_model_read` `read_ref` does not resolve to a declared biosphere-state entry | REJECT (a read pointing at nothing) |
 | `T6-COMPOSE` | 2 | a transfer's `scale_stack` / parent→child scales are inconsistent with the declared twin-hierarchy composition | REJECT |
+| `T7-CONCEPT` | vocabulary | a governed bare enum lacks its Systema Concept Entry `concept_ref` | FLAG (prefer-governed-ID) |
+| `T7-CONCEPT` | vocabulary | a `concept_ref` is not one of the 11 governed IDs, or is the wrong concept for its enum | REJECT |
 
 `T5-RESOLVE` is what makes `T1-CONST` / `T1-RESERVE` / `T4-REGEN` load-bearing: a source
 may not merely *claim* to be a world-model read — its ref must resolve to declared
@@ -86,9 +88,13 @@ substrate-*W* biosphere state at that `@<as_of>`. The checker also fails CI if a
 declared tooth is **never** exercised in the firing direction (no dead teeth), and
 asserts the admitted fixtures fire **no** tooth.
 
-A follow-up tooth `T7-CONCEPT` is documented (not yet enforced): once the ontogenesis
-concept-governance PR provides stable Systema Concept Entry IDs, reject vocabulary terms
-that do not resolve to a governed concept ID (bare-string → concept-ID).
+`T7-CONCEPT` is **ENFORCED** (no longer a documented-only follow-up). It binds the
+contract vocabulary to the governed concepts registered in **ontogenesis#141** (registry
+`Platform/Systema/`, `systema:concept:*`): a `concept_ref` sits beside each governed bare
+enum in `value_flow_binding.v1` / `twin_scale_transfer.v1` (and the composition record).
+The 11 governed IDs cover `carrying_capacity`, `natural_capital`,
+`extractive_nonrenewable`, `renewable_harvest`, `qol_index` + its `life_length` /
+`health` / `education` dimensions, and the three twin-scale terms.
 
 ## Consequences
 
@@ -126,11 +132,13 @@ that do not resolve to a governed concept ID (bare-string → concept-ID).
 
 ## Cross-references
 
-- **Ontogenesis (sibling agent).** The concept lifecycle / Systema Concept Entry
-  governs the *vocabulary* used here (`carrying_capacity`, `natural_capital`,
-  `renewable_harvest`, `qol_index`, twin-scale terms). This ADR *references* those
-  governed concepts and does not duplicate them; the terms should resolve against the
-  ontogenesis concept-governance PR once landed.
+- **Ontogenesis (sibling agent) — merged, ENFORCED.** The concept lifecycle / Systema
+  Concept Entry governs the *vocabulary* used here (`carrying_capacity`,
+  `natural_capital`, `extractive_nonrenewable`, `renewable_harvest`, `qol_index` + its
+  dimensions, and the three twin-scale terms). The governed IDs are registered in
+  **ontogenesis#141** (`Platform/Systema/`, `systema:concept:*`). This ADR *references*
+  those governed concepts by `concept_ref` and does not duplicate them; tooth
+  `T7-CONCEPT` enforces the binding (bare-string → concept-ID).
 - **economic-prophet**: `asset_ladder` (ALC-1) rung ontology; `risk_measures`
   (expected-shortfall) tail measure; welfare-annealing (WEA-1) dynamics +
   `welfare_annealing/gaia_binding.py` emitter, merged to main at

--- a/examples/biosphere/biosphere_state.global.2026-08-03.json
+++ b/examples/biosphere/biosphere_state.global.2026-08-03.json
@@ -1,0 +1,40 @@
+{
+  "state_version": "v1",
+  "state_type": "BiosphereState",
+  "state_id": "biosphere-state-global-2026-08-03",
+  "as_of": "2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "carrying_capacity": {
+    "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03",
+    "value_index": 0.83
+  },
+  "reserves": [
+    {
+      "stock": "reserve/hydrocarbon/basin-07",
+      "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03",
+      "floor": 200,
+      "current": 1000,
+      "renewable": false
+    },
+    {
+      "stock": "fishery/north-atlantic",
+      "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03",
+      "floor": 100,
+      "current": 500,
+      "renewable": true
+    }
+  ],
+  "regeneration_rates": [
+    {
+      "stock": "fishery/north-atlantic",
+      "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03",
+      "rate": 0.05
+    }
+  ],
+  "planetary_boundaries": [
+    {"name": "biosphere_integrity", "stock": "fishery/north-atlantic", "threshold": 100, "status": "within"},
+    {"name": "fossil_stock_depletion", "stock": "reserve/hydrocarbon/basin-07", "threshold": 200, "status": "at_risk"}
+  ],
+  "provenance": {"source": "gaia-world-model biosphere/resource state", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true}
+}

--- a/examples/economy/value_flow/binding.carrying_capacity_constant.invalid.json
+++ b/examples/economy/value_flow/binding.carrying_capacity_constant.invalid.json
@@ -6,25 +6,64 @@
   "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
-    "source": {"kind": "constant"},
+    "concept_ref": "systema:concept:carrying-capacity",
+    "source": {
+      "kind": "constant"
+    },
     "value_index": 1.0
   },
   "ecosystem_assets": [
     {
       "rung": "renewable_harvest",
+      "concept_ref": "systema:concept:renewable-harvest",
       "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
-      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
-      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+      "regeneration": {
+        "source": {
+          "kind": "world_model_read",
+          "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"
+        },
+        "rate": 0.05
+      },
+      "stock": {
+        "current": 500,
+        "non_renewable_draw": 0,
+        "reserve": {
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"
+          },
+          "floor": 100
+        }
+      }
     }
   ],
   "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
     "value": 0.72,
     "population_ref": "twin://human/population/global",
     "dimensions": [
-      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+      {
+        "name": "health",
+        "concept_ref": "systema:concept:qol-dim-health",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/health",
+          "population_ref": "twin://human/population/global"
+        }
+      }
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "reject", "tooth": "T1-CONST", "why": "carrying-capacity is a hardcoded constant, not a world-model read (free-parameter smell)"}
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "reject",
+    "tooth": "T1-CONST",
+    "why": "carrying-capacity is a hardcoded constant, not a world-model read (free-parameter smell)"
+  }
 }

--- a/examples/economy/value_flow/binding.carrying_capacity_constant.invalid.json
+++ b/examples/economy/value_flow/binding.carrying_capacity_constant.invalid.json
@@ -3,8 +3,8 @@
   "binding_type": "ValueFlowSubsystemBinding",
   "binding_id": "vfb-hardcoded-cc-2026-08-03",
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
-  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
-  "welfare_annealing_ref": "SocioProphet/economic-prophet@feat/welfare-annealing",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
     "source": {"kind": "constant"},
     "value_index": 1.0
@@ -24,7 +24,7 @@
       {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "reject", "tooth": "T1-CONST", "why": "carrying-capacity is a hardcoded constant, not a world-model read (free-parameter smell)"}
 }

--- a/examples/economy/value_flow/binding.carrying_capacity_constant.invalid.json
+++ b/examples/economy/value_flow/binding.carrying_capacity_constant.invalid.json
@@ -1,0 +1,30 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-hardcoded-cc-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@feat/welfare-annealing",
+  "carrying_capacity": {
+    "source": {"kind": "constant"},
+    "value_index": 1.0
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "renewable_harvest",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
+      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+    }
+  ],
+  "qol_index": {
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T1-CONST", "why": "carrying-capacity is a hardcoded constant, not a world-model read (free-parameter smell)"}
+}

--- a/examples/economy/value_flow/binding.concept_ref_missing.flag.json
+++ b/examples/economy/value_flow/binding.concept_ref_missing.flag.json
@@ -1,0 +1,30 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-concept-ref-missing-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "carrying_capacity": {
+    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "renewable_harvest",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
+      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+    }
+  ],
+  "qol_index": {
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "admit_with_flag", "tooth": "T7-CONCEPT", "why": "governed bare enums (carrying_capacity, renewable_harvest, qol_index, health) carry no concept_ref while governed IDs exist in ontogenesis#141: prefer-governed-ID flag"}
+}

--- a/examples/economy/value_flow/binding.concept_ref_ungoverned.invalid.json
+++ b/examples/economy/value_flow/binding.concept_ref_ungoverned.invalid.json
@@ -1,0 +1,33 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-concept-ref-ungoverned-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "carrying_capacity": {
+    "concept_ref": "systema:concept:carrying-capacity",
+    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "renewable_harvest",
+      "concept_ref": "systema:concept:unicorn-capital",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
+      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+    }
+  ],
+  "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "health", "concept_ref": "systema:concept:qol-dim-health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T7-CONCEPT", "why": "the renewable_harvest rung carries concept_ref systema:concept:unicorn-capital, which is not one of the 11 governed Systema Concept Entry IDs (ontogenesis#141)"}
+}

--- a/examples/economy/value_flow/binding.dangling_read_ref.invalid.json
+++ b/examples/economy/value_flow/binding.dangling_read_ref.invalid.json
@@ -3,7 +3,7 @@
   "binding_type": "ValueFlowSubsystemBinding",
   "binding_id": "vfb-dangling-read-ref-2026-08-03",
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
-  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
     "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/mars@2099-01-01"},
     "value_index": 0.83
@@ -23,7 +23,7 @@
       {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "reject", "tooth": "T5-RESOLVE", "why": "carrying-capacity read_ref gaia://biosphere/carrying_capacity/mars@2099-01-01 resolves to no declared biosphere state entry: a world_model_read pointing at nothing"}
 }

--- a/examples/economy/value_flow/binding.dangling_read_ref.invalid.json
+++ b/examples/economy/value_flow/binding.dangling_read_ref.invalid.json
@@ -1,0 +1,29 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-dangling-read-ref-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "carrying_capacity": {
+    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/mars@2099-01-01"},
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "renewable_harvest",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
+      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+    }
+  ],
+  "qol_index": {
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T5-RESOLVE", "why": "carrying-capacity read_ref gaia://biosphere/carrying_capacity/mars@2099-01-01 resolves to no declared biosphere state entry: a world_model_read pointing at nothing"}
+}

--- a/examples/economy/value_flow/binding.dangling_read_ref.invalid.json
+++ b/examples/economy/value_flow/binding.dangling_read_ref.invalid.json
@@ -5,25 +5,65 @@
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
   "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
-    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/mars@2099-01-01"},
+    "concept_ref": "systema:concept:carrying-capacity",
+    "source": {
+      "kind": "world_model_read",
+      "read_ref": "gaia://biosphere/carrying_capacity/mars@2099-01-01"
+    },
     "value_index": 0.83
   },
   "ecosystem_assets": [
     {
       "rung": "renewable_harvest",
+      "concept_ref": "systema:concept:renewable-harvest",
       "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
-      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
-      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+      "regeneration": {
+        "source": {
+          "kind": "world_model_read",
+          "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"
+        },
+        "rate": 0.05
+      },
+      "stock": {
+        "current": 500,
+        "non_renewable_draw": 0,
+        "reserve": {
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"
+          },
+          "floor": 100
+        }
+      }
     }
   ],
   "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
     "value": 0.72,
     "population_ref": "twin://human/population/global",
     "dimensions": [
-      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+      {
+        "name": "health",
+        "concept_ref": "systema:concept:qol-dim-health",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/health",
+          "population_ref": "twin://human/population/global"
+        }
+      }
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "reject", "tooth": "T5-RESOLVE", "why": "carrying-capacity read_ref gaia://biosphere/carrying_capacity/mars@2099-01-01 resolves to no declared biosphere state entry: a world_model_read pointing at nothing"}
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "reject",
+    "tooth": "T5-RESOLVE",
+    "why": "carrying-capacity read_ref gaia://biosphere/carrying_capacity/mars@2099-01-01 resolves to no declared biosphere state entry: a world_model_read pointing at nothing"
+  }
 }

--- a/examples/economy/value_flow/binding.ecosystem_regen_constant.invalid.json
+++ b/examples/economy/value_flow/binding.ecosystem_regen_constant.invalid.json
@@ -3,7 +3,7 @@
   "binding_type": "ValueFlowSubsystemBinding",
   "binding_id": "vfb-regen-constant-2026-08-03",
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
-  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
     "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
     "value_index": 0.83
@@ -23,7 +23,7 @@
       {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "reject", "tooth": "T4-REGEN", "why": "renewable regeneration rate is a hardcoded constant, not a world-model read"}
 }

--- a/examples/economy/value_flow/binding.ecosystem_regen_constant.invalid.json
+++ b/examples/economy/value_flow/binding.ecosystem_regen_constant.invalid.json
@@ -1,0 +1,29 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-regen-constant-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "carrying_capacity": {
+    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "renewable_harvest",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {"source": {"kind": "constant"}, "rate": 0.20},
+      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+    }
+  ],
+  "qol_index": {
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T4-REGEN", "why": "renewable regeneration rate is a hardcoded constant, not a world-model read"}
+}

--- a/examples/economy/value_flow/binding.ecosystem_regen_constant.invalid.json
+++ b/examples/economy/value_flow/binding.ecosystem_regen_constant.invalid.json
@@ -5,25 +5,64 @@
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
   "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
-    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "concept_ref": "systema:concept:carrying-capacity",
+    "source": {
+      "kind": "world_model_read",
+      "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"
+    },
     "value_index": 0.83
   },
   "ecosystem_assets": [
     {
       "rung": "renewable_harvest",
+      "concept_ref": "systema:concept:renewable-harvest",
       "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
-      "regeneration": {"source": {"kind": "constant"}, "rate": 0.20},
-      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+      "regeneration": {
+        "source": {
+          "kind": "constant"
+        },
+        "rate": 0.2
+      },
+      "stock": {
+        "current": 500,
+        "non_renewable_draw": 0,
+        "reserve": {
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"
+          },
+          "floor": 100
+        }
+      }
     }
   ],
   "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
     "value": 0.72,
     "population_ref": "twin://human/population/global",
     "dimensions": [
-      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+      {
+        "name": "health",
+        "concept_ref": "systema:concept:qol-dim-health",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/health",
+          "population_ref": "twin://human/population/global"
+        }
+      }
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "reject", "tooth": "T4-REGEN", "why": "renewable regeneration rate is a hardcoded constant, not a world-model read"}
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "reject",
+    "tooth": "T4-REGEN",
+    "why": "renewable regeneration rate is a hardcoded constant, not a world-model read"
+  }
 }

--- a/examples/economy/value_flow/binding.qol_exogenous.invalid.json
+++ b/examples/economy/value_flow/binding.qol_exogenous.invalid.json
@@ -3,7 +3,7 @@
   "binding_type": "ValueFlowSubsystemBinding",
   "binding_id": "vfb-exogenous-qol-2026-08-03",
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
-  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
     "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
     "value_index": 0.83
@@ -24,7 +24,7 @@
       {"name": "education", "derivation": {"kind": "exogenous"}}
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "reject", "tooth": "T3-QOL", "why": "the education QoL dimension is exogenous, not aggregated from human-digital-twin state"}
 }

--- a/examples/economy/value_flow/binding.qol_exogenous.invalid.json
+++ b/examples/economy/value_flow/binding.qol_exogenous.invalid.json
@@ -5,26 +5,72 @@
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
   "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
-    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "concept_ref": "systema:concept:carrying-capacity",
+    "source": {
+      "kind": "world_model_read",
+      "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"
+    },
     "value_index": 0.83
   },
   "ecosystem_assets": [
     {
       "rung": "renewable_harvest",
+      "concept_ref": "systema:concept:renewable-harvest",
       "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
-      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
-      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+      "regeneration": {
+        "source": {
+          "kind": "world_model_read",
+          "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"
+        },
+        "rate": 0.05
+      },
+      "stock": {
+        "current": 500,
+        "non_renewable_draw": 0,
+        "reserve": {
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"
+          },
+          "floor": 100
+        }
+      }
     }
   ],
   "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
     "value": 0.95,
     "population_ref": "twin://human/population/global",
     "dimensions": [
-      {"name": "life_length", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/life_length", "population_ref": "twin://human/population/global"}},
-      {"name": "education", "derivation": {"kind": "exogenous"}}
+      {
+        "name": "life_length",
+        "concept_ref": "systema:concept:qol-dim-life-length",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/life_length",
+          "population_ref": "twin://human/population/global"
+        }
+      },
+      {
+        "name": "education",
+        "concept_ref": "systema:concept:qol-dim-education",
+        "derivation": {
+          "kind": "exogenous"
+        }
+      }
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "reject", "tooth": "T3-QOL", "why": "the education QoL dimension is exogenous, not aggregated from human-digital-twin state"}
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "reject",
+    "tooth": "T3-QOL",
+    "why": "the education QoL dimension is exogenous, not aggregated from human-digital-twin state"
+  }
 }

--- a/examples/economy/value_flow/binding.qol_exogenous.invalid.json
+++ b/examples/economy/value_flow/binding.qol_exogenous.invalid.json
@@ -1,0 +1,30 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-exogenous-qol-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "carrying_capacity": {
+    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "renewable_harvest",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"}, "rate": 0.05},
+      "stock": {"current": 500, "non_renewable_draw": 0, "reserve": {"source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"}, "floor": 100}}
+    }
+  ],
+  "qol_index": {
+    "value": 0.95,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "life_length", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/life_length", "population_ref": "twin://human/population/global"}},
+      {"name": "education", "derivation": {"kind": "exogenous"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T3-QOL", "why": "the education QoL dimension is exogenous, not aggregated from human-digital-twin state"}
+}

--- a/examples/economy/value_flow/binding.reserve_breach.flag.json
+++ b/examples/economy/value_flow/binding.reserve_breach.flag.json
@@ -6,32 +6,63 @@
   "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
-    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "concept_ref": "systema:concept:carrying-capacity",
+    "source": {
+      "kind": "world_model_read",
+      "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"
+    },
     "value_index": 0.83
   },
   "ecosystem_assets": [
     {
       "rung": "extractive_nonrenewable",
+      "concept_ref": "systema:concept:extractive-nonrenewable",
       "biosphere_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07",
-      "regeneration": {"source": {"kind": "none"}},
+      "regeneration": {
+        "source": {
+          "kind": "none"
+        }
+      },
       "stock": {
         "current": 1000,
         "non_renewable_draw": 900,
         "reserve": {
-          "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03"},
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03"
+          },
           "floor": 200
         }
       }
     }
   ],
   "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
     "value": 0.72,
     "population_ref": "twin://human/population/global",
     "dimensions": [
-      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+      {
+        "name": "health",
+        "concept_ref": "systema:concept:qol-dim-health",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/health",
+          "population_ref": "twin://human/population/global"
+        }
+      }
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "admit_with_flag", "tooth": "T1-RESERVE", "why": "draw of 900 takes the stock (1000) to 100, below the world-model declared reserve floor (200): planetary-boundary breach"}
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "admit_with_flag",
+    "tooth": "T1-RESERVE",
+    "why": "draw of 900 takes the stock (1000) to 100, below the world-model declared reserve floor (200): planetary-boundary breach"
+  }
 }

--- a/examples/economy/value_flow/binding.reserve_breach.flag.json
+++ b/examples/economy/value_flow/binding.reserve_breach.flag.json
@@ -1,0 +1,37 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-reserve-breach-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@feat/welfare-annealing",
+  "carrying_capacity": {
+    "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "extractive_nonrenewable",
+      "biosphere_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07",
+      "regeneration": {"source": {"kind": "none"}},
+      "stock": {
+        "current": 1000,
+        "non_renewable_draw": 900,
+        "reserve": {
+          "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03"},
+          "floor": 200
+        }
+      }
+    }
+  ],
+  "qol_index": {
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "admit_with_flag", "tooth": "T1-RESERVE", "why": "draw of 900 takes the stock (1000) to 100, below the world-model declared reserve floor (200): planetary-boundary breach"}
+}

--- a/examples/economy/value_flow/binding.reserve_breach.flag.json
+++ b/examples/economy/value_flow/binding.reserve_breach.flag.json
@@ -3,8 +3,8 @@
   "binding_type": "ValueFlowSubsystemBinding",
   "binding_id": "vfb-reserve-breach-2026-08-03",
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
-  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
-  "welfare_annealing_ref": "SocioProphet/economic-prophet@feat/welfare-annealing",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
     "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"},
     "value_index": 0.83
@@ -31,7 +31,7 @@
       {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}}
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "admit_with_flag", "tooth": "T1-RESERVE", "why": "draw of 900 takes the stock (1000) to 100, below the world-model declared reserve floor (200): planetary-boundary breach"}
 }

--- a/examples/economy/value_flow/binding.world_model_read.valid.json
+++ b/examples/economy/value_flow/binding.world_model_read.valid.json
@@ -6,6 +6,7 @@
   "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
+    "concept_ref": "systema:concept:carrying-capacity",
     "source": {
       "kind": "world_model_read",
       "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"
@@ -15,44 +16,92 @@
   "ecosystem_assets": [
     {
       "rung": "extractive_nonrenewable",
+      "concept_ref": "systema:concept:extractive-nonrenewable",
       "biosphere_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07",
-      "regeneration": {"source": {"kind": "none"}},
+      "regeneration": {
+        "source": {
+          "kind": "none"
+        }
+      },
       "stock": {
         "current": 1000,
         "non_renewable_draw": 300,
         "reserve": {
-          "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03"},
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03"
+          },
           "floor": 200
         }
       }
     },
     {
       "rung": "renewable_harvest",
+      "concept_ref": "systema:concept:renewable-harvest",
       "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
       "regeneration": {
-        "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"},
+        "source": {
+          "kind": "world_model_read",
+          "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"
+        },
         "rate": 0.05
       },
       "stock": {
         "current": 500,
         "non_renewable_draw": 0,
         "reserve": {
-          "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"},
+          "source": {
+            "kind": "world_model_read",
+            "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"
+          },
           "floor": 100
         }
       }
     }
   ],
   "qol_index": {
+    "concept_ref": "systema:concept:qol-index",
     "value": 0.72,
     "population_ref": "twin://human/population/global",
     "dimensions": [
-      {"name": "life_length", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/life_length", "population_ref": "twin://human/population/global"}},
-      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}},
-      {"name": "education", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/education", "population_ref": "twin://human/population/global"}}
+      {
+        "name": "life_length",
+        "concept_ref": "systema:concept:qol-dim-life-length",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/life_length",
+          "population_ref": "twin://human/population/global"
+        }
+      },
+      {
+        "name": "health",
+        "concept_ref": "systema:concept:qol-dim-health",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/health",
+          "population_ref": "twin://human/population/global"
+        }
+      },
+      {
+        "name": "education",
+        "concept_ref": "systema:concept:qol-dim-education",
+        "derivation": {
+          "kind": "twin_aggregate",
+          "from_twin_dimension": "twin://human/dimension/education",
+          "population_ref": "twin://human/population/global"
+        }
+      }
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "admit"}
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "admit"
+  }
 }

--- a/examples/economy/value_flow/binding.world_model_read.valid.json
+++ b/examples/economy/value_flow/binding.world_model_read.valid.json
@@ -1,0 +1,58 @@
+{
+  "binding_version": "v1",
+  "binding_type": "ValueFlowSubsystemBinding",
+  "binding_id": "vfb-global-welfare-2026-08-03",
+  "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
+  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@feat/welfare-annealing",
+  "carrying_capacity": {
+    "source": {
+      "kind": "world_model_read",
+      "read_ref": "gaia://biosphere/carrying_capacity/global@2026-08-03"
+    },
+    "value_index": 0.83
+  },
+  "ecosystem_assets": [
+    {
+      "rung": "extractive_nonrenewable",
+      "biosphere_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07",
+      "regeneration": {"source": {"kind": "none"}},
+      "stock": {
+        "current": 1000,
+        "non_renewable_draw": 300,
+        "reserve": {
+          "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03"},
+          "floor": 200
+        }
+      }
+    },
+    {
+      "rung": "renewable_harvest",
+      "biosphere_ref": "gaia://biosphere/fishery/north-atlantic",
+      "regeneration": {
+        "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03"},
+        "rate": 0.05
+      },
+      "stock": {
+        "current": 500,
+        "non_renewable_draw": 0,
+        "reserve": {
+          "source": {"kind": "world_model_read", "read_ref": "gaia://biosphere/fishery/north-atlantic/floor@2026-08-03"},
+          "floor": 100
+        }
+      }
+    }
+  ],
+  "qol_index": {
+    "value": 0.72,
+    "population_ref": "twin://human/population/global",
+    "dimensions": [
+      {"name": "life_length", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/life_length", "population_ref": "twin://human/population/global"}},
+      {"name": "health", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/health", "population_ref": "twin://human/population/global"}},
+      {"name": "education", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/education", "population_ref": "twin://human/population/global"}}
+    ]
+  },
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "admit"}
+}

--- a/examples/economy/value_flow/binding.world_model_read.valid.json
+++ b/examples/economy/value_flow/binding.world_model_read.valid.json
@@ -3,8 +3,8 @@
   "binding_type": "ValueFlowSubsystemBinding",
   "binding_id": "vfb-global-welfare-2026-08-03",
   "world_model_ref": "SocioProphet/gaia-world-model@907f6b121134e6f49c1da69d51d91ec47f77648e",
-  "economic_spine_ref": "SocioProphet/economic-prophet@e29ce66",
-  "welfare_annealing_ref": "SocioProphet/economic-prophet@feat/welfare-annealing",
+  "economic_spine_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+  "welfare_annealing_ref": "SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
   "carrying_capacity": {
     "source": {
       "kind": "world_model_read",
@@ -52,7 +52,7 @@
       {"name": "education", "derivation": {"kind": "twin_aggregate", "from_twin_dimension": "twin://human/dimension/education", "population_ref": "twin://human/population/global"}}
     ]
   },
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "admit"}
 }

--- a/examples/economy/value_flow/transfer.composition_inconsistent.invalid.json
+++ b/examples/economy/value_flow/transfer.composition_inconsistent.invalid.json
@@ -1,0 +1,16 @@
+{
+  "transfer_version": "v1",
+  "transfer_type": "TwinScaleValueTransfer",
+  "transfer_id": "tvt-composition-inconsistent-2026-08-03",
+  "scale_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
+  "parent": {"scale": "galactic_space_twin", "ref": "twin://space/galaxy", "value": 1000},
+  "children": [
+    {"scale": "human_digital_twin", "ref": "twin://human/cohort/a", "value": 1000}
+  ],
+  "declared_sources": [],
+  "declared_sinks": [],
+  "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T6-COMPOSE", "why": "parent scale galactic_space_twin -> child scale human_digital_twin skips world_economic_twin; not an adjacent parent->child edge in the declared twin-hierarchy composition"}
+}

--- a/examples/economy/value_flow/transfer.composition_inconsistent.invalid.json
+++ b/examples/economy/value_flow/transfer.composition_inconsistent.invalid.json
@@ -2,15 +2,42 @@
   "transfer_version": "v1",
   "transfer_type": "TwinScaleValueTransfer",
   "transfer_id": "tvt-composition-inconsistent-2026-08-03",
-  "scale_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
-  "parent": {"scale": "galactic_space_twin", "ref": "twin://space/galaxy", "value": 1000},
+  "scale_stack": [
+    "galactic_space_twin",
+    "world_economic_twin",
+    "human_digital_twin"
+  ],
+  "parent": {
+    "scale": "galactic_space_twin",
+    "concept_ref": "systema:concept:galactic-space-twin",
+    "ref": "twin://space/galaxy",
+    "value": 1000
+  },
   "children": [
-    {"scale": "human_digital_twin", "ref": "twin://human/cohort/a", "value": 1000}
+    {
+      "scale": "human_digital_twin",
+      "concept_ref": "systema:concept:human-digital-twin",
+      "ref": "twin://human/cohort/a",
+      "value": 1000
+    }
   ],
   "declared_sources": [],
   "declared_sinks": [],
-  "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "reject", "tooth": "T6-COMPOSE", "why": "parent scale galactic_space_twin -> child scale human_digital_twin skips world_economic_twin; not an adjacent parent->child edge in the declared twin-hierarchy composition"}
+  "conservation": {
+    "rule": "parent_value == sum(children) + sum(sinks) - sum(sources)",
+    "tolerance": 1e-06
+  },
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "reject",
+    "tooth": "T6-COMPOSE",
+    "why": "parent scale galactic_space_twin -> child scale human_digital_twin skips world_economic_twin; not an adjacent parent->child edge in the declared twin-hierarchy composition"
+  }
 }

--- a/examples/economy/value_flow/transfer.composition_inconsistent.invalid.json
+++ b/examples/economy/value_flow/transfer.composition_inconsistent.invalid.json
@@ -10,7 +10,7 @@
   "declared_sources": [],
   "declared_sinks": [],
   "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "reject", "tooth": "T6-COMPOSE", "why": "parent scale galactic_space_twin -> child scale human_digital_twin skips world_economic_twin; not an adjacent parent->child edge in the declared twin-hierarchy composition"}
 }

--- a/examples/economy/value_flow/transfer.conserved.valid.json
+++ b/examples/economy/value_flow/transfer.conserved.valid.json
@@ -2,16 +2,52 @@
   "transfer_version": "v1",
   "transfer_type": "TwinScaleValueTransfer",
   "transfer_id": "tvt-world-to-human-2026-08-03",
-  "scale_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
-  "parent": {"scale": "world_economic_twin", "ref": "twin://economy/world", "value": 1000},
+  "scale_stack": [
+    "galactic_space_twin",
+    "world_economic_twin",
+    "human_digital_twin"
+  ],
+  "parent": {
+    "scale": "world_economic_twin",
+    "concept_ref": "systema:concept:world-economic-twin",
+    "ref": "twin://economy/world",
+    "value": 1000
+  },
   "children": [
-    {"scale": "human_digital_twin", "ref": "twin://human/cohort/a", "value": 600},
-    {"scale": "human_digital_twin", "ref": "twin://human/cohort/b", "value": 300}
+    {
+      "scale": "human_digital_twin",
+      "concept_ref": "systema:concept:human-digital-twin",
+      "ref": "twin://human/cohort/a",
+      "value": 600
+    },
+    {
+      "scale": "human_digital_twin",
+      "concept_ref": "systema:concept:human-digital-twin",
+      "ref": "twin://human/cohort/b",
+      "value": 300
+    }
   ],
   "declared_sources": [],
-  "declared_sinks": [{"ref": "sink://depreciation/2026-08-03", "amount": 100}],
-  "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "admit", "why": "1000 == 600 + 300 + 100(sink) - 0(source): value conserved (IC-1)"}
+  "declared_sinks": [
+    {
+      "ref": "sink://depreciation/2026-08-03",
+      "amount": 100
+    }
+  ],
+  "conservation": {
+    "rule": "parent_value == sum(children) + sum(sinks) - sum(sources)",
+    "tolerance": 1e-06
+  },
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "admit",
+    "why": "1000 == 600 + 300 + 100(sink) - 0(source): value conserved (IC-1)"
+  }
 }

--- a/examples/economy/value_flow/transfer.conserved.valid.json
+++ b/examples/economy/value_flow/transfer.conserved.valid.json
@@ -1,0 +1,17 @@
+{
+  "transfer_version": "v1",
+  "transfer_type": "TwinScaleValueTransfer",
+  "transfer_id": "tvt-world-to-human-2026-08-03",
+  "scale_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
+  "parent": {"scale": "world_economic_twin", "ref": "twin://economy/world", "value": 1000},
+  "children": [
+    {"scale": "human_digital_twin", "ref": "twin://human/cohort/a", "value": 600},
+    {"scale": "human_digital_twin", "ref": "twin://human/cohort/b", "value": 300}
+  ],
+  "declared_sources": [],
+  "declared_sinks": [{"ref": "sink://depreciation/2026-08-03", "amount": 100}],
+  "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "admit", "why": "1000 == 600 + 300 + 100(sink) - 0(source): value conserved (IC-1)"}
+}

--- a/examples/economy/value_flow/transfer.conserved.valid.json
+++ b/examples/economy/value_flow/transfer.conserved.valid.json
@@ -11,7 +11,7 @@
   "declared_sources": [],
   "declared_sinks": [{"ref": "sink://depreciation/2026-08-03", "amount": 100}],
   "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "admit", "why": "1000 == 600 + 300 + 100(sink) - 0(source): value conserved (IC-1)"}
 }

--- a/examples/economy/value_flow/transfer.value_created.invalid.json
+++ b/examples/economy/value_flow/transfer.value_created.invalid.json
@@ -2,16 +2,48 @@
   "transfer_version": "v1",
   "transfer_type": "TwinScaleValueTransfer",
   "transfer_id": "tvt-value-from-nothing-2026-08-03",
-  "scale_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
-  "parent": {"scale": "world_economic_twin", "ref": "twin://economy/world", "value": 1000},
+  "scale_stack": [
+    "galactic_space_twin",
+    "world_economic_twin",
+    "human_digital_twin"
+  ],
+  "parent": {
+    "scale": "world_economic_twin",
+    "concept_ref": "systema:concept:world-economic-twin",
+    "ref": "twin://economy/world",
+    "value": 1000
+  },
   "children": [
-    {"scale": "human_digital_twin", "ref": "twin://human/cohort/a", "value": 600},
-    {"scale": "human_digital_twin", "ref": "twin://human/cohort/b", "value": 600}
+    {
+      "scale": "human_digital_twin",
+      "concept_ref": "systema:concept:human-digital-twin",
+      "ref": "twin://human/cohort/a",
+      "value": 600
+    },
+    {
+      "scale": "human_digital_twin",
+      "concept_ref": "systema:concept:human-digital-twin",
+      "ref": "twin://human/cohort/b",
+      "value": 600
+    }
   ],
   "declared_sources": [],
   "declared_sinks": [],
-  "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
-  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": true},
-  "_expected": {"verdict": "reject", "tooth": "T2-CONSERVE", "why": "children sum to 1200 but the parent aggregate is 1000 with no receipted source: 200 of value created out of nothing"}
+  "conservation": {
+    "rule": "parent_value == sum(children) + sum(sinks) - sum(sources)",
+    "tolerance": 1e-06
+  },
+  "provenance": {
+    "produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": true
+  },
+  "_expected": {
+    "verdict": "reject",
+    "tooth": "T2-CONSERVE",
+    "why": "children sum to 1200 but the parent aggregate is 1000 with no receipted source: 200 of value created out of nothing"
+  }
 }

--- a/examples/economy/value_flow/transfer.value_created.invalid.json
+++ b/examples/economy/value_flow/transfer.value_created.invalid.json
@@ -1,0 +1,17 @@
+{
+  "transfer_version": "v1",
+  "transfer_type": "TwinScaleValueTransfer",
+  "transfer_id": "tvt-value-from-nothing-2026-08-03",
+  "scale_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
+  "parent": {"scale": "world_economic_twin", "ref": "twin://economy/world", "value": 1000},
+  "children": [
+    {"scale": "human_digital_twin", "ref": "twin://human/cohort/a", "value": 600},
+    {"scale": "human_digital_twin", "ref": "twin://human/cohort/b", "value": 600}
+  ],
+  "declared_sources": [],
+  "declared_sinks": [],
+  "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
+  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": true},
+  "_expected": {"verdict": "reject", "tooth": "T2-CONSERVE", "why": "children sum to 1200 but the parent aggregate is 1000 with no receipted source: 200 of value created out of nothing"}
+}

--- a/examples/economy/value_flow/transfer.value_created.invalid.json
+++ b/examples/economy/value_flow/transfer.value_created.invalid.json
@@ -11,7 +11,7 @@
   "declared_sources": [],
   "declared_sinks": [],
   "conservation": {"rule": "parent_value == sum(children) + sum(sinks) - sum(sources)", "tolerance": 1e-06},
-  "provenance": {"produced_by": "economic-prophet@feat/welfare-annealing", "as_of": "2026-08-03"},
+  "provenance": {"produced_by": "economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583", "as_of": "2026-08-03"},
   "classification": {"sensitivity": "internal", "synthetic": true},
   "_expected": {"verdict": "reject", "tooth": "T2-CONSERVE", "why": "children sum to 1200 but the parent aggregate is 1000 with no receipted source: 200 of value created out of nothing"}
 }

--- a/gaia/twins/composition.v1.json
+++ b/gaia/twins/composition.v1.json
@@ -2,12 +2,40 @@
   "composition_version": "v1",
   "composition_type": "TwinHierarchyComposition",
   "composition_id": "twin-hierarchy-galactic-world-human",
-  "ordered_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
-  "scales": [
-    {"scale": "galactic_space_twin", "parent": null, "child": "world_economic_twin", "surface_ref": "client-vue SpaceTwin.vue (Self<->Body<->Universe 5D cube)"},
-    {"scale": "world_economic_twin", "parent": "galactic_space_twin", "child": "human_digital_twin", "surface_ref": "SocioProphet/economic-prophet (the value-flow subsystem / economic spine)"},
-    {"scale": "human_digital_twin", "parent": "world_economic_twin", "child": null, "surface_ref": "SocioProphet/prophet-health + gaia/twins/human"}
+  "ordered_stack": [
+    "galactic_space_twin",
+    "world_economic_twin",
+    "human_digital_twin"
   ],
-  "provenance": {"decision": "ADR-0003", "as_of": "2026-08-03"},
-  "classification": {"sensitivity": "internal", "synthetic": false}
+  "scales": [
+    {
+      "scale": "galactic_space_twin",
+      "concept_ref": "systema:concept:galactic-space-twin",
+      "parent": null,
+      "child": "world_economic_twin",
+      "surface_ref": "client-vue SpaceTwin.vue (Self<->Body<->Universe 5D cube)"
+    },
+    {
+      "scale": "world_economic_twin",
+      "concept_ref": "systema:concept:world-economic-twin",
+      "parent": "galactic_space_twin",
+      "child": "human_digital_twin",
+      "surface_ref": "SocioProphet/economic-prophet (the value-flow subsystem / economic spine)"
+    },
+    {
+      "scale": "human_digital_twin",
+      "concept_ref": "systema:concept:human-digital-twin",
+      "parent": "world_economic_twin",
+      "child": null,
+      "surface_ref": "SocioProphet/prophet-health + gaia/twins/human"
+    }
+  ],
+  "provenance": {
+    "decision": "ADR-0003",
+    "as_of": "2026-08-03"
+  },
+  "classification": {
+    "sensitivity": "internal",
+    "synthetic": false
+  }
 }

--- a/gaia/twins/composition.v1.json
+++ b/gaia/twins/composition.v1.json
@@ -1,0 +1,13 @@
+{
+  "composition_version": "v1",
+  "composition_type": "TwinHierarchyComposition",
+  "composition_id": "twin-hierarchy-galactic-world-human",
+  "ordered_stack": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"],
+  "scales": [
+    {"scale": "galactic_space_twin", "parent": null, "child": "world_economic_twin", "surface_ref": "client-vue SpaceTwin.vue (Self<->Body<->Universe 5D cube)"},
+    {"scale": "world_economic_twin", "parent": "galactic_space_twin", "child": "human_digital_twin", "surface_ref": "SocioProphet/economic-prophet (the value-flow subsystem / economic spine)"},
+    {"scale": "human_digital_twin", "parent": "world_economic_twin", "child": null, "surface_ref": "SocioProphet/prophet-health + gaia/twins/human"}
+  ],
+  "provenance": {"decision": "ADR-0003", "as_of": "2026-08-03"},
+  "classification": {"sensitivity": "internal", "synthetic": false}
+}

--- a/schemas/biosphere/biosphere_state.v1.schema.json
+++ b/schemas/biosphere/biosphere_state.v1.schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gaia.socioprophet.ai/schemas/biosphere/biosphere_state.v1.schema.json",
+  "title": "GAIA Biosphere / Resource State v1",
+  "description": "A declared snapshot of the world-model substrate W biosphere/resource state that the value-flow subsystem contract READS. It is the resolution target for a ValueFlowSubsystemBinding's world_model_read references: a carrying-capacity index, declared non-renewable reserves and their floors, renewable regeneration rates, and planetary-boundary declarations. Each entry declares the canonical read_ref it answers, temporally keyed by @<as_of>. A value-flow read_ref that does not resolve to a declared entry here is dangling and is REJECTED (tooth T5-RESOLVE).",
+  "type": "object",
+  "required": [
+    "state_version",
+    "state_type",
+    "state_id",
+    "as_of",
+    "world_model_ref",
+    "carrying_capacity",
+    "reserves",
+    "regeneration_rates",
+    "planetary_boundaries",
+    "provenance",
+    "classification"
+  ],
+  "properties": {
+    "state_version": {"type": "string", "const": "v1"},
+    "state_type": {"type": "string", "const": "BiosphereState"},
+    "state_id": {"type": "string"},
+    "as_of": {"type": "string", "description": "Temporal key for this snapshot, e.g. 2026-08-03. read_refs resolve at this @<as_of>."},
+    "world_model_ref": {"type": "string", "pattern": "^SocioProphet/gaia-world-model@.+$"},
+    "carrying_capacity": {
+      "type": "object",
+      "description": "The global (or scoped) carrying-capacity index the welfare-annealing discount reads.",
+      "required": ["read_ref", "value_index"],
+      "properties": {
+        "read_ref": {"type": "string", "description": "Canonical ref this entry answers, e.g. gaia://biosphere/carrying_capacity/global@2026-08-03."},
+        "value_index": {"type": "number"}
+      }
+    },
+    "reserves": {
+      "type": "array",
+      "description": "Declared non-renewable (and renewable stock) reserves and their world-model floors. The floor read_ref is the resolution target for a binding's stock.reserve.source.read_ref.",
+      "items": {
+        "type": "object",
+        "required": ["stock", "read_ref", "floor", "renewable"],
+        "properties": {
+          "stock": {"type": "string", "description": "Stock identity, e.g. reserve/hydrocarbon/basin-07 or fishery/north-atlantic."},
+          "read_ref": {"type": "string", "description": "Canonical floor ref, e.g. gaia://biosphere/reserve/hydrocarbon/basin-07/floor@2026-08-03."},
+          "floor": {"type": "number", "description": "The world-model declared reserve floor for this stock."},
+          "current": {"type": "number"},
+          "renewable": {"type": "boolean"}
+        }
+      }
+    },
+    "regeneration_rates": {
+      "type": "array",
+      "description": "Declared renewable regeneration rates. The read_ref is the resolution target for a binding's renewable_harvest regeneration.source.read_ref.",
+      "items": {
+        "type": "object",
+        "required": ["stock", "read_ref", "rate"],
+        "properties": {
+          "stock": {"type": "string"},
+          "read_ref": {"type": "string", "description": "Canonical regeneration ref, e.g. gaia://biosphere/fishery/north-atlantic/regeneration@2026-08-03."},
+          "rate": {"type": "number"}
+        }
+      }
+    },
+    "planetary_boundaries": {
+      "type": "array",
+      "description": "Declared planetary-boundary thresholds. A value-flow that breaches one is the planetary-boundary / paper-inductance false-growth analog (see tooth T1-RESERVE).",
+      "items": {
+        "type": "object",
+        "required": ["name", "stock", "threshold", "status"],
+        "properties": {
+          "name": {"type": "string"},
+          "stock": {"type": "string"},
+          "threshold": {"type": "number"},
+          "status": {"type": "string", "enum": ["within", "at_risk", "breached"]}
+        }
+      }
+    },
+    "provenance": {"type": "object"},
+    "classification": {"type": "object"}
+  }
+}

--- a/schemas/economy/twin_hierarchy_composition.v1.schema.json
+++ b/schemas/economy/twin_hierarchy_composition.v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gaia.socioprophet.ai/schemas/economy/twin_hierarchy_composition.v1.schema.json",
+  "title": "GAIA Twin-Hierarchy Composition v1",
+  "description": "A first-class declaration of the world-model digital-twin hierarchy: the galactic/space twin, the world economic twin (the economic spine), and the human digital twin, with explicit parent/child scale relationships. It is the authority a TwinScaleValueTransfer's scale_stack and parent/child scales must be consistent with. A transfer inconsistent with this composition is REJECTED (tooth T6-COMPOSE).",
+  "type": "object",
+  "required": [
+    "composition_version",
+    "composition_type",
+    "composition_id",
+    "ordered_stack",
+    "scales",
+    "provenance",
+    "classification"
+  ],
+  "properties": {
+    "composition_version": {"type": "string", "const": "v1"},
+    "composition_type": {"type": "string", "const": "TwinHierarchyComposition"},
+    "composition_id": {"type": "string"},
+    "ordered_stack": {
+      "type": "array",
+      "description": "Outer-to-inner scale order. Canonically [galactic_space_twin, world_economic_twin, human_digital_twin].",
+      "items": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "scales": {
+      "type": "array",
+      "description": "Per-scale composition record with explicit parent/child edges. A null parent is the outermost scale; a null child is the innermost.",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "required": ["scale", "parent", "child"],
+        "properties": {
+          "scale": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+          "parent": {"type": ["string", "null"], "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin", null]},
+          "child": {"type": ["string", "null"], "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin", null]},
+          "surface_ref": {"type": "string", "description": "Optional pointer to the twin's surface/engine, e.g. client-vue SpaceTwin.vue, SocioProphet/economic-prophet, SocioProphet/prophet-health."}
+        }
+      }
+    },
+    "provenance": {"type": "object"},
+    "classification": {"type": "object"}
+  }
+}

--- a/schemas/economy/twin_hierarchy_composition.v1.schema.json
+++ b/schemas/economy/twin_hierarchy_composition.v1.schema.json
@@ -33,6 +33,11 @@
         "required": ["scale", "parent", "child"],
         "properties": {
           "scale": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+          "concept_ref": {
+            "type": "string",
+            "pattern": "^systema:concept:[a-z0-9-]+$",
+            "description": "Governed Systema Concept Entry ID for this twin-scale (ontogenesis#141, Platform/Systema/), e.g. systema:concept:world-economic-twin."
+          },
           "parent": {"type": ["string", "null"], "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin", null]},
           "child": {"type": ["string", "null"], "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin", null]},
           "surface_ref": {"type": "string", "description": "Optional pointer to the twin's surface/engine, e.g. client-vue SpaceTwin.vue, SocioProphet/economic-prophet, SocioProphet/prophet-health."}

--- a/schemas/economy/twin_scale_transfer.v1.schema.json
+++ b/schemas/economy/twin_scale_transfer.v1.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gaia.socioprophet.ai/schemas/economy/twin_scale_transfer.v1.schema.json",
+  "title": "GAIA Twin-Scale Value Transfer v1",
+  "description": "A value flow across an adjacent boundary of the world-model twin hierarchy galactic/space twin <-> world economic twin (the economic spine) <-> human digital twin (Binding 2). Value flows are the exchange dynamics of the scale stack. Invariant IC-1: value is CONSERVED across a twin-scale aggregation. A cross-scale flow that creates value out of nothing (parent value exceeds the sum of children net of receipted sources/sinks) is REJECTED (tooth T2-CONSERVE).",
+  "type": "object",
+  "required": [
+    "transfer_version",
+    "transfer_type",
+    "transfer_id",
+    "scale_stack",
+    "parent",
+    "children",
+    "conservation",
+    "provenance",
+    "classification"
+  ],
+  "properties": {
+    "transfer_version": {"type": "string", "const": "v1"},
+    "transfer_type": {"type": "string", "const": "TwinScaleValueTransfer"},
+    "transfer_id": {"type": "string"},
+    "scale_stack": {
+      "type": "array",
+      "description": "The declared world-model twin hierarchy, in outer-to-inner order. MUST be exactly [galactic_space_twin, world_economic_twin, human_digital_twin].",
+      "items": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "parent": {
+      "type": "object",
+      "description": "The coarser (outer) scale of this transfer.",
+      "required": ["scale", "value"],
+      "properties": {
+        "scale": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+        "ref": {"type": "string"},
+        "value": {"type": "number"}
+      }
+    },
+    "children": {
+      "type": "array",
+      "description": "The finer (inner) scale constituents whose values aggregate into the parent.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["scale", "value"],
+        "properties": {
+          "scale": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+          "ref": {"type": "string"},
+          "value": {"type": "number"}
+        }
+      }
+    },
+    "declared_sources": {
+      "type": "array",
+      "description": "Receipted injections into the aggregate (a source outside the child set). Unreceipted creation is not permitted.",
+      "items": {
+        "type": "object",
+        "required": ["ref", "amount"],
+        "properties": {"ref": {"type": "string"}, "amount": {"type": "number"}}
+      }
+    },
+    "declared_sinks": {
+      "type": "array",
+      "description": "Receipted removals from the aggregate (a sink outside the child set).",
+      "items": {
+        "type": "object",
+        "required": ["ref", "amount"],
+        "properties": {"ref": {"type": "string"}, "amount": {"type": "number"}}
+      }
+    },
+    "conservation": {
+      "type": "object",
+      "description": "The IC-1 conservation rule. parent.value == sum(children.value) + sum(declared_sinks.amount) - sum(declared_sources.amount), within tolerance.",
+      "required": ["rule", "tolerance"],
+      "properties": {
+        "rule": {"type": "string", "const": "parent_value == sum(children) + sum(sinks) - sum(sources)"},
+        "tolerance": {"type": "number", "minimum": 0}
+      }
+    },
+    "provenance": {"type": "object"},
+    "classification": {"type": "object"}
+  }
+}

--- a/schemas/economy/twin_scale_transfer.v1.schema.json
+++ b/schemas/economy/twin_scale_transfer.v1.schema.json
@@ -32,6 +32,7 @@
       "required": ["scale", "value"],
       "properties": {
         "scale": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+        "concept_ref": {"$ref": "#/$defs/concept_ref"},
         "ref": {"type": "string"},
         "value": {"type": "number"}
       }
@@ -45,6 +46,7 @@
         "required": ["scale", "value"],
         "properties": {
           "scale": {"type": "string", "enum": ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]},
+          "concept_ref": {"$ref": "#/$defs/concept_ref"},
           "ref": {"type": "string"},
           "value": {"type": "number"}
         }
@@ -79,5 +81,12 @@
     },
     "provenance": {"type": "object"},
     "classification": {"type": "object"}
+  },
+  "$defs": {
+    "concept_ref": {
+      "type": "string",
+      "pattern": "^systema:concept:[a-z0-9-]+$",
+      "description": "Governed Systema Concept Entry ID for the twin-scale bare enum this sits beside, from the ontogenesis concept registry (ontogenesis#141, Platform/Systema/), e.g. systema:concept:world-economic-twin. Absent where governed => FLAGGED; not a governed ID (or wrong concept) => REJECTED (tooth T7-CONCEPT)."
+    }
   }
 }

--- a/schemas/economy/value_flow_binding.v1.schema.json
+++ b/schemas/economy/value_flow_binding.v1.schema.json
@@ -32,7 +32,7 @@
     },
     "welfare_annealing_ref": {
       "type": "string",
-      "description": "Optional forward soft-ref to the in-flight welfare-annealing dynamics, e.g. SocioProphet/economic-prophet@feat/welfare-annealing. Consumed by branch-ref; its files are never edited by this contract.",
+      "description": "Optional pinned soft-ref to the welfare-annealing dynamics (WEA-1), now merged to economic-prophet main, e.g. SocioProphet/economic-prophet@a51a23f52dfe7b0e984a42a19a762dabe714a583 (module src/open_ep_framework/welfare_annealing/, whose gaia_binding.py emits this value_flow_binding.v1 record). Consumed by reference; never vendored; its files are never edited by this contract.",
       "pattern": "^SocioProphet/economic-prophet@.+$"
     },
     "carrying_capacity": {

--- a/schemas/economy/value_flow_binding.v1.schema.json
+++ b/schemas/economy/value_flow_binding.v1.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gaia.socioprophet.ai/schemas/economy/value_flow_binding.v1.schema.json",
+  "title": "GAIA Value-Flow Subsystem Binding v1",
+  "description": "A binding manifest that any Economic-Prophet / welfare-annealing value-flow run MUST present to be admissible as the value-flow subsystem of the GAIA world model. It does NOT redefine value; it binds the economic spine UPWARD into the world model by REFERENCE. The carrying-capacity discount and the Jacob's-ladder natural-capital / renewable base MUST be READS of the GAIA biosphere/resource state (WorldModelSubstrate W), not free parameters; the QoL objective's dimensions MUST aggregate from human-digital-twin state (population = sum of twins). Consume-not-fork: economic-prophet kernels are referenced by pinned ref, never vendored.",
+  "type": "object",
+  "required": [
+    "binding_version",
+    "binding_type",
+    "binding_id",
+    "world_model_ref",
+    "economic_spine_ref",
+    "carrying_capacity",
+    "ecosystem_assets",
+    "qol_index",
+    "provenance",
+    "classification"
+  ],
+  "properties": {
+    "binding_version": {"type": "string", "const": "v1"},
+    "binding_type": {"type": "string", "const": "ValueFlowSubsystemBinding"},
+    "binding_id": {"type": "string"},
+    "world_model_ref": {
+      "type": "string",
+      "description": "Pinned reference to the world-model substrate W being read, e.g. SocioProphet/gaia-world-model@<sha>. Biosphere/resource reads resolve against this ref.",
+      "pattern": "^SocioProphet/gaia-world-model@.+$"
+    },
+    "economic_spine_ref": {
+      "type": "string",
+      "description": "Pinned soft-ref to the producing economic spine, e.g. SocioProphet/economic-prophet@<sha>. Never vendored.",
+      "pattern": "^SocioProphet/economic-prophet@.+$"
+    },
+    "welfare_annealing_ref": {
+      "type": "string",
+      "description": "Optional forward soft-ref to the in-flight welfare-annealing dynamics, e.g. SocioProphet/economic-prophet@feat/welfare-annealing. Consumed by branch-ref; its files are never edited by this contract.",
+      "pattern": "^SocioProphet/economic-prophet@.+$"
+    },
+    "carrying_capacity": {
+      "type": "object",
+      "description": "The welfare-annealing carrying-capacity discount. Its source MUST be a world-model read (Binding 1). A hardcoded constant is the free-parameter smell and is REJECTED (tooth T1-CONST).",
+      "required": ["source", "value_index"],
+      "properties": {
+        "source": {
+          "type": "object",
+          "required": ["kind"],
+          "properties": {
+            "kind": {"type": "string", "enum": ["world_model_read", "constant"]},
+            "read_ref": {
+              "type": "string",
+              "description": "Resolvable world-model read, e.g. gaia://biosphere/carrying_capacity/global@<as_of>. Required when kind == world_model_read."
+            }
+          }
+        },
+        "value_index": {"type": "number"}
+      }
+    },
+    "ecosystem_assets": {
+      "type": "array",
+      "description": "Jacob's-ladder ecosystem / natural-capital assets. Each binds to the GAIA biosphere state (Binding 4). Renewable regeneration rate MUST be a world-model read. A non-renewable draw taking the stock below the world-model's declared reserve floor is FLAGGED (planetary-boundary breach, the paper-inductance false-growth analog; tooth T1-RESERVE).",
+      "items": {
+        "type": "object",
+        "required": ["rung", "biosphere_ref", "regeneration", "stock"],
+        "properties": {
+          "rung": {"type": "string", "enum": ["natural_capital", "extractive_nonrenewable", "renewable_harvest"]},
+          "biosphere_ref": {
+            "type": "string",
+            "description": "World-model biosphere state reference, e.g. gaia://biosphere/forest/amazon."
+          },
+          "regeneration": {
+            "type": "object",
+            "required": ["source"],
+            "properties": {
+              "source": {
+                "type": "object",
+                "required": ["kind"],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["world_model_read", "constant", "none"],
+                    "description": "For rung == renewable_harvest the regeneration rate MUST be world_model_read (constant/none is REJECTED, tooth T4-REGEN). For depleting rungs 'none' is admissible."
+                  },
+                  "read_ref": {"type": "string"}
+                }
+              },
+              "rate": {"type": "number"}
+            }
+          },
+          "stock": {
+            "type": "object",
+            "required": ["current", "reserve"],
+            "properties": {
+              "current": {"type": "number"},
+              "non_renewable_draw": {"type": "number"},
+              "reserve": {
+                "type": "object",
+                "required": ["source", "floor"],
+                "properties": {
+                  "source": {
+                    "type": "object",
+                    "required": ["kind"],
+                    "properties": {
+                      "kind": {"type": "string", "enum": ["world_model_read", "constant"]},
+                      "read_ref": {"type": "string"}
+                    }
+                  },
+                  "floor": {"type": "number", "description": "The world-model's declared reserve floor for this stock."}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "qol_index": {
+      "type": "object",
+      "description": "The welfare objective's quality-of-life index. Its life-length / health / education dimensions MUST aggregate from human-digital-twin state (population = sum of twins) (Binding 3). A population QoL index not derivable from constituent human-twin dimensions is REJECTED (tooth T3-QOL).",
+      "required": ["value", "dimensions"],
+      "properties": {
+        "value": {"type": "number"},
+        "population_ref": {"type": "string", "description": "Population aggregate reference, e.g. twin://human/population/global."},
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "derivation"],
+            "properties": {
+              "name": {"type": "string", "enum": ["life_length", "health", "education"]},
+              "derivation": {
+                "type": "object",
+                "required": ["kind"],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": ["twin_aggregate", "exogenous"],
+                    "description": "MUST be twin_aggregate. exogenous is the free-parameter smell and is REJECTED."
+                  },
+                  "from_twin_dimension": {
+                    "type": "string",
+                    "description": "Human-digital-twin state dimension this aggregates from, e.g. twin://human/dimension/health. Required when kind == twin_aggregate."
+                  },
+                  "population_ref": {"type": "string"}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "provenance": {"type": "object"},
+    "classification": {"type": "object"}
+  }
+}

--- a/schemas/economy/value_flow_binding.v1.schema.json
+++ b/schemas/economy/value_flow_binding.v1.schema.json
@@ -40,6 +40,7 @@
       "description": "The welfare-annealing carrying-capacity discount. Its source MUST be a world-model read (Binding 1). A hardcoded constant is the free-parameter smell and is REJECTED (tooth T1-CONST).",
       "required": ["source", "value_index"],
       "properties": {
+        "concept_ref": {"$ref": "#/$defs/concept_ref"},
         "source": {
           "type": "object",
           "required": ["kind"],
@@ -62,6 +63,7 @@
         "required": ["rung", "biosphere_ref", "regeneration", "stock"],
         "properties": {
           "rung": {"type": "string", "enum": ["natural_capital", "extractive_nonrenewable", "renewable_harvest"]},
+          "concept_ref": {"$ref": "#/$defs/concept_ref"},
           "biosphere_ref": {
             "type": "string",
             "description": "World-model biosphere state reference, e.g. gaia://biosphere/forest/amazon."
@@ -116,6 +118,7 @@
       "description": "The welfare objective's quality-of-life index. Its life-length / health / education dimensions MUST aggregate from human-digital-twin state (population = sum of twins) (Binding 3). A population QoL index not derivable from constituent human-twin dimensions is REJECTED (tooth T3-QOL).",
       "required": ["value", "dimensions"],
       "properties": {
+        "concept_ref": {"$ref": "#/$defs/concept_ref"},
         "value": {"type": "number"},
         "population_ref": {"type": "string", "description": "Population aggregate reference, e.g. twin://human/population/global."},
         "dimensions": {
@@ -125,6 +128,7 @@
             "required": ["name", "derivation"],
             "properties": {
               "name": {"type": "string", "enum": ["life_length", "health", "education"]},
+              "concept_ref": {"$ref": "#/$defs/concept_ref"},
               "derivation": {
                 "type": "object",
                 "required": ["kind"],
@@ -148,5 +152,12 @@
     },
     "provenance": {"type": "object"},
     "classification": {"type": "object"}
+  },
+  "$defs": {
+    "concept_ref": {
+      "type": "string",
+      "pattern": "^systema:concept:[a-z0-9-]+$",
+      "description": "Governed Systema Concept Entry ID for the bare enum this sits beside, from the ontogenesis concept registry (ontogenesis#141, Platform/Systema/). One of the 11 governed IDs, e.g. systema:concept:carrying-capacity, systema:concept:renewable-harvest, systema:concept:world-economic-twin. A binding that uses a governed bare enum without its concept_ref is FLAGGED (prefer-governed-ID); a concept_ref that is not a governed ID (or is the wrong concept for the enum) is REJECTED (tooth T7-CONCEPT)."
+    }
   }
 }

--- a/scripts/validate_value_flow_subsystem.py
+++ b/scripts/validate_value_flow_subsystem.py
@@ -36,6 +36,17 @@ Teeth:
   T4-REGEN    (Binding 4, ecosystem <-> biosphere): a renewable_harvest rung whose
               regeneration rate is a constant instead of a world-model read is REJECTED.
 
+  T5-RESOLVE  (Bindings 1/4, resolution): a world_model_read whose read_ref does NOT
+              resolve to a declared biosphere-state entry (examples/biosphere/**) is
+              REJECTED -- a read pointing at nothing. This is what makes T1-CONST,
+              T1-RESERVE and T4-REGEN load-bearing: a source may not merely *claim* to be
+              a world-model read, it must resolve to declared substrate-W state.
+
+  T6-COMPOSE  (Binding 2, composition): a TwinScaleValueTransfer whose scale_stack is not
+              the declared ordered stack, or whose parent->child scales are not an
+              adjacent parent->child edge in the twin-hierarchy composition record
+              (gaia/twins/composition.v1.json), is REJECTED.
+
 Consume-by-reference: the carrying-capacity discount and welfare objective from
 economic-prophet@feat/welfare-annealing; the Jacob's-ladder rung ontology
 (natural_capital / extractive_nonrenewable / renewable_harvest) from
@@ -54,10 +65,15 @@ from typing import Any, Dict, List, Tuple
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURES = ROOT / "examples" / "economy" / "value_flow"
+BIOSPHERE_STATES = ROOT / "examples" / "biosphere"
+COMPOSITION_RECORD = ROOT / "gaia" / "twins" / "composition.v1.json"
 
 # Every tooth the contract declares. Each MUST fire on at least one fixture (no dead
 # teeth) and MUST NOT fire on the admitted fixtures.
-DECLARED_TEETH = {"T1-CONST", "T1-RESERVE", "T2-CONSERVE", "T3-QOL", "T4-REGEN"}
+DECLARED_TEETH = {
+    "T1-CONST", "T1-RESERVE", "T2-CONSERVE", "T3-QOL", "T4-REGEN",
+    "T5-RESOLVE", "T6-COMPOSE",
+}
 
 # Bootstrap structural requirements (dependency-light, mirrors the GAIA contract-fixture
 # validator). The full JSON Schema lives alongside each record in schemas/economy/.
@@ -97,13 +113,60 @@ def _missing(record: Dict[str, Any], required: List[str]) -> List[str]:
     return [k for k in required if k not in record]
 
 
-def judge_binding(rec: Dict[str, Any]) -> Verdict:
+def load_biosphere_refs() -> set[str]:
+    """Every read_ref declared by the biosphere/resource state (the resolution target)."""
+    refs: set[str] = set()
+    if not BIOSPHERE_STATES.is_dir():
+        return refs
+    for path in sorted(BIOSPHERE_STATES.glob("*.json")):
+        state = json.loads(path.read_text(encoding="utf-8"))
+        cc = state.get("carrying_capacity", {}).get("read_ref")
+        if cc:
+            refs.add(cc)
+        for entry in state.get("reserves", []) + state.get("regeneration_rates", []):
+            if entry.get("read_ref"):
+                refs.add(entry["read_ref"])
+    return refs
+
+
+def load_composition() -> Dict[str, Any]:
+    """The declared twin-hierarchy composition record, or {} if absent."""
+    if not COMPOSITION_RECORD.exists():
+        return {}
+    return json.loads(COMPOSITION_RECORD.read_text(encoding="utf-8"))
+
+
+def _binding_read_refs(rec: Dict[str, Any]) -> List[str]:
+    """Every read_ref a binding claims as a world_model_read (carrying-capacity,
+    renewable regeneration, and reserve floors)."""
+    refs: List[str] = []
+    cc = rec.get("carrying_capacity", {}).get("source", {})
+    if cc.get("kind") == "world_model_read":
+        refs.append(cc.get("read_ref"))
+    for asset in rec.get("ecosystem_assets", []):
+        regen = asset.get("regeneration", {}).get("source", {})
+        if regen.get("kind") == "world_model_read":
+            refs.append(regen.get("read_ref"))
+        reserve = asset.get("stock", {}).get("reserve", {}).get("source", {})
+        if reserve.get("kind") == "world_model_read":
+            refs.append(reserve.get("read_ref"))
+    return refs
+
+
+def judge_binding(rec: Dict[str, Any], biosphere_refs: set[str]) -> Verdict:
     v = Verdict()
 
     # T1-CONST -- carrying capacity must be a world-model read, not a free constant.
     cc_kind = rec.get("carrying_capacity", {}).get("source", {}).get("kind")
     if cc_kind != "world_model_read":
         v.rejected_by.append("T1-CONST")
+
+    # T5-RESOLVE -- every claimed world_model_read must resolve to a declared biosphere
+    # state entry. A source may not merely *claim* to read from W; the ref must exist.
+    for ref in _binding_read_refs(rec):
+        if not ref or ref not in biosphere_refs:
+            if "T5-RESOLVE" not in v.rejected_by:
+                v.rejected_by.append("T5-RESOLVE")
 
     # T3-QOL -- every QoL dimension must aggregate from a human-twin dimension.
     for dim in rec.get("qol_index", {}).get("dimensions", []):
@@ -132,13 +195,20 @@ def judge_binding(rec: Dict[str, Any]) -> Verdict:
     return v
 
 
-def judge_transfer(rec: Dict[str, Any]) -> Verdict:
+def judge_transfer(rec: Dict[str, Any], composition: Dict[str, Any]) -> Verdict:
     v = Verdict()
 
-    # Structural: the declared scale stack must be the canonical hierarchy.
-    if rec.get("scale_stack") != CANONICAL_SCALE_STACK:
-        v.rejected_by.append("T2-CONSERVE")
-        return v
+    # T6-COMPOSE -- the transfer must be consistent with the declared twin-hierarchy
+    # composition: its scale_stack must be the declared ordered stack, and its
+    # parent->child scales must be a declared adjacent parent->child edge.
+    ordered = composition.get("ordered_stack", CANONICAL_SCALE_STACK)
+    edges = {(s.get("scale"), s.get("child")) for s in composition.get("scales", [])}
+    parent_scale = rec.get("parent", {}).get("scale")
+    child_scales = {c.get("scale") for c in rec.get("children", [])}
+    stack_ok = rec.get("scale_stack") == ordered
+    edges_ok = all((parent_scale, cs) in edges for cs in child_scales) if edges else True
+    if not stack_ok or not edges_ok:
+        v.rejected_by.append("T6-COMPOSE")
 
     parent = rec.get("parent", {}).get("value", 0) or 0
     children = sum((c.get("value", 0) or 0) for c in rec.get("children", []))
@@ -154,14 +224,14 @@ def judge_transfer(rec: Dict[str, Any]) -> Verdict:
     return v
 
 
-def judge(rec: Dict[str, Any]) -> Tuple[str, Verdict, List[str]]:
+def judge(rec: Dict[str, Any], biosphere_refs: set[str], composition: Dict[str, Any]) -> Tuple[str, Verdict, List[str]]:
     """Return (kind, verdict, structural_errors)."""
     if rec.get("binding_type") == "ValueFlowSubsystemBinding":
         errs = _missing(rec, REQUIRED_BINDING)
-        return "binding", judge_binding(rec), errs
+        return "binding", judge_binding(rec, biosphere_refs), errs
     if rec.get("transfer_type") == "TwinScaleValueTransfer":
         errs = _missing(rec, REQUIRED_TRANSFER)
-        return "transfer", judge_transfer(rec), errs
+        return "transfer", judge_transfer(rec, composition), errs
     return "unknown", Verdict(), ["unrecognized record: no binding_type/transfer_type"]
 
 
@@ -173,6 +243,15 @@ def main() -> int:
     fixtures = sorted(FIXTURES.glob("*.json"))
     if not fixtures:
         print(f"FAIL: no fixtures under {FIXTURES}", file=sys.stderr)
+        return 1
+
+    biosphere_refs = load_biosphere_refs()
+    composition = load_composition()
+    if not biosphere_refs:
+        print(f"FAIL: no biosphere state declared under {BIOSPHERE_STATES}", file=sys.stderr)
+        return 1
+    if not composition.get("ordered_stack"):
+        print(f"FAIL: twin-hierarchy composition record missing: {COMPOSITION_RECORD}", file=sys.stderr)
         return 1
 
     failures: List[str] = []
@@ -192,7 +271,7 @@ def main() -> int:
             failures.append(f"{rel}: fixture carries no `_expected` verdict block")
             continue
 
-        kind, verdict, struct_errs = judge(rec)
+        kind, verdict, struct_errs = judge(rec, biosphere_refs, composition)
         if kind == "unknown":
             failures.append(f"{rel}: {struct_errs}")
             continue

--- a/scripts/validate_value_flow_subsystem.py
+++ b/scripts/validate_value_flow_subsystem.py
@@ -47,8 +47,13 @@ Teeth:
               adjacent parent->child edge in the twin-hierarchy composition record
               (gaia/twins/composition.v1.json), is REJECTED.
 
+  T7-CONCEPT  (concept governance, ontogenesis#141): a governed bare enum used WITHOUT its
+              governed Systema Concept Entry `concept_ref` (where one of the 11 exists) is
+              FLAGGED -- prefer-governed-ID. A `concept_ref` that is not one of the 11
+              governed IDs, or is the wrong governed concept for its enum, is REJECTED.
+
 Consume-by-reference: the carrying-capacity discount and welfare objective from
-economic-prophet@feat/welfare-annealing; the Jacob's-ladder rung ontology
+economic-prophet welfare-annealing (WEA-1); the Jacob's-ladder rung ontology
 (natural_capital / extractive_nonrenewable / renewable_harvest) from
 economic-prophet asset_ladder (ALC-1); the human-twin state dimensions from
 gaia/twins/human/twin-schema.json. Nothing is vendored.
@@ -72,8 +77,27 @@ COMPOSITION_RECORD = ROOT / "gaia" / "twins" / "composition.v1.json"
 # teeth) and MUST NOT fire on the admitted fixtures.
 DECLARED_TEETH = {
     "T1-CONST", "T1-RESERVE", "T2-CONSERVE", "T3-QOL", "T4-REGEN",
-    "T5-RESOLVE", "T6-COMPOSE",
+    "T5-RESOLVE", "T6-COMPOSE", "T7-CONCEPT",
 }
+
+# Governed Systema Concept Entry IDs (ontogenesis#141, registry Platform/Systema/): the
+# bare enum a binding/transfer may use -> its governed concept ID. A governed enum used
+# without its concept_ref is FLAGGED; a concept_ref outside these 11 (or wrong for the
+# enum) is REJECTED (tooth T7-CONCEPT).
+GOVERNED_CONCEPTS = {
+    "carrying_capacity": "systema:concept:carrying-capacity",
+    "natural_capital": "systema:concept:natural-capital",
+    "extractive_nonrenewable": "systema:concept:extractive-nonrenewable",
+    "renewable_harvest": "systema:concept:renewable-harvest",
+    "qol_index": "systema:concept:qol-index",
+    "life_length": "systema:concept:qol-dim-life-length",
+    "health": "systema:concept:qol-dim-health",
+    "education": "systema:concept:qol-dim-education",
+    "galactic_space_twin": "systema:concept:galactic-space-twin",
+    "world_economic_twin": "systema:concept:world-economic-twin",
+    "human_digital_twin": "systema:concept:human-digital-twin",
+}
+GOVERNED_IDS = set(GOVERNED_CONCEPTS.values())
 
 # Bootstrap structural requirements (dependency-light, mirrors the GAIA contract-fixture
 # validator). The full JSON Schema lives alongside each record in schemas/economy/.
@@ -153,6 +177,51 @@ def _binding_read_refs(rec: Dict[str, Any]) -> List[str]:
     return refs
 
 
+def _governed_terms_in_binding(rec: Dict[str, Any]):
+    """Yield (object, governed-enum-value) pairs a binding carries: the object that
+    should hold a concept_ref, and the bare enum it must match."""
+    cc = rec.get("carrying_capacity")
+    if isinstance(cc, dict):
+        yield cc, "carrying_capacity"
+    qi = rec.get("qol_index")
+    if isinstance(qi, dict):
+        yield qi, "qol_index"
+        for dim in qi.get("dimensions", []):
+            if dim.get("name"):
+                yield dim, dim["name"]
+    for asset in rec.get("ecosystem_assets", []):
+        if asset.get("rung"):
+            yield asset, asset["rung"]
+
+
+def _governed_terms_in_transfer(rec: Dict[str, Any]):
+    parent = rec.get("parent")
+    if isinstance(parent, dict) and parent.get("scale"):
+        yield parent, parent["scale"]
+    for child in rec.get("children", []):
+        if child.get("scale"):
+            yield child, child["scale"]
+
+
+def apply_t7_concept(v: Verdict, terms) -> None:
+    """T7-CONCEPT -- concept governance (ontogenesis#141). For each governed bare enum:
+    a missing concept_ref is FLAGGED (prefer-governed-ID); a concept_ref that is not a
+    governed ID, or is the wrong governed concept for the enum, is REJECTED."""
+    for obj, enum_val in terms:
+        expected = GOVERNED_CONCEPTS.get(enum_val)
+        if expected is None:
+            continue
+        cref = obj.get("concept_ref")
+        if cref is None:
+            if "T7-CONCEPT" not in v.flagged_by and "T7-CONCEPT" not in v.rejected_by:
+                v.flagged_by.append("T7-CONCEPT")
+        elif cref not in GOVERNED_IDS or cref != expected:
+            if "T7-CONCEPT" in v.flagged_by:
+                v.flagged_by.remove("T7-CONCEPT")
+            if "T7-CONCEPT" not in v.rejected_by:
+                v.rejected_by.append("T7-CONCEPT")
+
+
 def judge_binding(rec: Dict[str, Any], biosphere_refs: set[str]) -> Verdict:
     v = Verdict()
 
@@ -160,6 +229,9 @@ def judge_binding(rec: Dict[str, Any], biosphere_refs: set[str]) -> Verdict:
     cc_kind = rec.get("carrying_capacity", {}).get("source", {}).get("kind")
     if cc_kind != "world_model_read":
         v.rejected_by.append("T1-CONST")
+
+    # T7-CONCEPT -- governed vocabulary must reference its Systema Concept Entry ID.
+    apply_t7_concept(v, _governed_terms_in_binding(rec))
 
     # T5-RESOLVE -- every claimed world_model_read must resolve to a declared biosphere
     # state entry. A source may not merely *claim* to read from W; the ref must exist.
@@ -220,6 +292,9 @@ def judge_transfer(rec: Dict[str, Any], composition: Dict[str, Any]) -> Verdict:
     residual = parent - (children + sinks - sources)
     if abs(residual) > tol:
         v.rejected_by.append("T2-CONSERVE")
+
+    # T7-CONCEPT -- governed twin-scale vocabulary must reference its concept ID.
+    apply_t7_concept(v, _governed_terms_in_transfer(rec))
 
     return v
 

--- a/scripts/validate_value_flow_subsystem.py
+++ b/scripts/validate_value_flow_subsystem.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Validate the GAIA value-flow subsystem contract -- with teeth in BOTH directions.
+
+This binds the estate's economic spine (Economic Prophet omnirisk/EP + the in-flight
+welfare-annealing dynamics) UPWARD into the GAIA world model and the digital-twin
+hierarchy. The economic spine is the *value-flow subsystem* of the world model: its
+carrying-capacity term and natural-capital base are READS of the world-model biosphere
+state, its QoL objective AGGREGATES from human-digital-twin state, and value flows are
+the exchange dynamics across the galactic <-> world-economic <-> human twin stack.
+
+A control that never fires is suspect (feedback: control-that-cannot-fail). So this
+checker asserts BOTH that valid fixtures are admitted AND that every invalid fixture is
+rejected/flagged for its *specific* tooth, and it FAILS if any tooth is never exercised
+in the firing direction (no dead teeth).
+
+Teeth:
+
+  T1-CONST    (Binding 1, carrying-capacity <-> biosphere): a binding whose
+              carrying_capacity.source.kind == "constant" (a hardcoded free parameter
+              instead of a world-model read) is REJECTED -- the free-parameter smell.
+
+  T1-RESERVE  (Binding 1/4): a value-flow that draws a non-renewable stock below the
+              world-model's declared reserve floor is FLAGGED -- a planetary-boundary
+              breach (the paper-inductance false-growth analog). Admitted-with-flag, not
+              rejected: the run is real, the flag is the receipt.
+
+  T2-CONSERVE (Binding 2, twin-hierarchy value conservation, IC-1): a cross-scale value
+              flow where parent.value != sum(children) + sum(sinks) - sum(sources), i.e.
+              value is created out of nothing, is REJECTED.
+
+  T3-QOL      (Binding 3, QoL <-> human digital twin): a population QoL index with any
+              dimension not derivable from constituent human-twin dimensions
+              (derivation.kind != "twin_aggregate", or a twin_aggregate lacking its
+              from_twin_dimension) is REJECTED -- the exogenous-QoL smell.
+
+  T4-REGEN    (Binding 4, ecosystem <-> biosphere): a renewable_harvest rung whose
+              regeneration rate is a constant instead of a world-model read is REJECTED.
+
+Consume-by-reference: the carrying-capacity discount and welfare objective from
+economic-prophet@feat/welfare-annealing; the Jacob's-ladder rung ontology
+(natural_capital / extractive_nonrenewable / renewable_harvest) from
+economic-prophet asset_ladder (ALC-1); the human-twin state dimensions from
+gaia/twins/human/twin-schema.json. Nothing is vendored.
+
+Deterministic, stdlib only (json, sys, pathlib). No third-party dependency, so CI is
+bulletproof. Self-validating: fixtures carry an `_expected` verdict this checker asserts.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = ROOT / "examples" / "economy" / "value_flow"
+
+# Every tooth the contract declares. Each MUST fire on at least one fixture (no dead
+# teeth) and MUST NOT fire on the admitted fixtures.
+DECLARED_TEETH = {"T1-CONST", "T1-RESERVE", "T2-CONSERVE", "T3-QOL", "T4-REGEN"}
+
+# Bootstrap structural requirements (dependency-light, mirrors the GAIA contract-fixture
+# validator). The full JSON Schema lives alongside each record in schemas/economy/.
+REQUIRED_BINDING = [
+    "binding_version", "binding_type", "binding_id", "world_model_ref",
+    "economic_spine_ref", "carrying_capacity", "ecosystem_assets", "qol_index",
+    "provenance", "classification",
+]
+REQUIRED_TRANSFER = [
+    "transfer_version", "transfer_type", "transfer_id", "scale_stack", "parent",
+    "children", "conservation", "provenance", "classification",
+]
+CANONICAL_SCALE_STACK = ["galactic_space_twin", "world_economic_twin", "human_digital_twin"]
+
+
+class Verdict:
+    """Outcome of judging one record: an admit/reject decision plus any flags fired."""
+
+    def __init__(self) -> None:
+        self.rejected_by: List[str] = []
+        self.flagged_by: List[str] = []
+
+    @property
+    def decision(self) -> str:
+        if self.rejected_by:
+            return "reject"
+        if self.flagged_by:
+            return "admit_with_flag"
+        return "admit"
+
+    @property
+    def teeth(self) -> List[str]:
+        return self.rejected_by + self.flagged_by
+
+
+def _missing(record: Dict[str, Any], required: List[str]) -> List[str]:
+    return [k for k in required if k not in record]
+
+
+def judge_binding(rec: Dict[str, Any]) -> Verdict:
+    v = Verdict()
+
+    # T1-CONST -- carrying capacity must be a world-model read, not a free constant.
+    cc_kind = rec.get("carrying_capacity", {}).get("source", {}).get("kind")
+    if cc_kind != "world_model_read":
+        v.rejected_by.append("T1-CONST")
+
+    # T3-QOL -- every QoL dimension must aggregate from a human-twin dimension.
+    for dim in rec.get("qol_index", {}).get("dimensions", []):
+        deriv = dim.get("derivation", {})
+        if deriv.get("kind") != "twin_aggregate" or not deriv.get("from_twin_dimension"):
+            v.rejected_by.append("T3-QOL")
+            break
+
+    for asset in rec.get("ecosystem_assets", []):
+        rung = asset.get("rung")
+        regen_kind = asset.get("regeneration", {}).get("source", {}).get("kind")
+        # T4-REGEN -- renewable regeneration rate must be a world-model read.
+        if rung == "renewable_harvest" and regen_kind != "world_model_read":
+            if "T4-REGEN" not in v.rejected_by:
+                v.rejected_by.append("T4-REGEN")
+        # T1-RESERVE -- a non-renewable draw below the declared reserve floor is flagged.
+        stock = asset.get("stock", {})
+        draw = stock.get("non_renewable_draw", 0) or 0
+        current = stock.get("current", 0) or 0
+        floor = stock.get("reserve", {}).get("floor", 0) or 0
+        if rung in ("natural_capital", "extractive_nonrenewable") and draw > 0:
+            if (current - draw) < floor:
+                if "T1-RESERVE" not in v.flagged_by:
+                    v.flagged_by.append("T1-RESERVE")
+
+    return v
+
+
+def judge_transfer(rec: Dict[str, Any]) -> Verdict:
+    v = Verdict()
+
+    # Structural: the declared scale stack must be the canonical hierarchy.
+    if rec.get("scale_stack") != CANONICAL_SCALE_STACK:
+        v.rejected_by.append("T2-CONSERVE")
+        return v
+
+    parent = rec.get("parent", {}).get("value", 0) or 0
+    children = sum((c.get("value", 0) or 0) for c in rec.get("children", []))
+    sinks = sum((s.get("amount", 0) or 0) for s in rec.get("declared_sinks", []))
+    sources = sum((s.get("amount", 0) or 0) for s in rec.get("declared_sources", []))
+    tol = rec.get("conservation", {}).get("tolerance", 0) or 0
+
+    # T2-CONSERVE (IC-1) -- value must be conserved across the aggregation.
+    residual = parent - (children + sinks - sources)
+    if abs(residual) > tol:
+        v.rejected_by.append("T2-CONSERVE")
+
+    return v
+
+
+def judge(rec: Dict[str, Any]) -> Tuple[str, Verdict, List[str]]:
+    """Return (kind, verdict, structural_errors)."""
+    if rec.get("binding_type") == "ValueFlowSubsystemBinding":
+        errs = _missing(rec, REQUIRED_BINDING)
+        return "binding", judge_binding(rec), errs
+    if rec.get("transfer_type") == "TwinScaleValueTransfer":
+        errs = _missing(rec, REQUIRED_TRANSFER)
+        return "transfer", judge_transfer(rec), errs
+    return "unknown", Verdict(), ["unrecognized record: no binding_type/transfer_type"]
+
+
+def main() -> int:
+    if not FIXTURES.is_dir():
+        print(f"FAIL: fixtures directory not found: {FIXTURES}", file=sys.stderr)
+        return 1
+
+    fixtures = sorted(FIXTURES.glob("*.json"))
+    if not fixtures:
+        print(f"FAIL: no fixtures under {FIXTURES}", file=sys.stderr)
+        return 1
+
+    failures: List[str] = []
+    fired_teeth: set[str] = set()
+    checked = 0
+
+    for path in fixtures:
+        rel = path.relative_to(ROOT)
+        try:
+            rec = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            failures.append(f"{rel}: not valid JSON: {exc}")
+            continue
+
+        expected = rec.get("_expected")
+        if not expected:
+            failures.append(f"{rel}: fixture carries no `_expected` verdict block")
+            continue
+
+        kind, verdict, struct_errs = judge(rec)
+        if kind == "unknown":
+            failures.append(f"{rel}: {struct_errs}")
+            continue
+
+        # Admitted records must be structurally complete; rejected ones need not be.
+        if expected.get("verdict") in ("admit", "admit_with_flag") and struct_errs:
+            failures.append(f"{rel}: admitted record missing required fields: {struct_errs}")
+
+        want_verdict = expected.get("verdict")
+        want_tooth = expected.get("tooth")
+
+        if verdict.decision != want_verdict:
+            failures.append(
+                f"{rel}: verdict mismatch -- expected {want_verdict!r} got "
+                f"{verdict.decision!r} (teeth fired: {verdict.teeth or 'none'})"
+            )
+        elif want_tooth and want_tooth not in verdict.teeth:
+            failures.append(
+                f"{rel}: expected tooth {want_tooth!r} to fire, but fired: "
+                f"{verdict.teeth or 'none'}"
+            )
+
+        for t in verdict.teeth:
+            fired_teeth.add(t)
+
+        marker = {"admit": "ADMIT", "admit_with_flag": "FLAG", "reject": "REJECT"}[verdict.decision]
+        print(f"  [{marker:6}] {rel}  teeth={verdict.teeth or '-'}  expected={want_verdict}")
+        checked += 1
+
+    # No dead teeth: every declared tooth must have fired on some fixture.
+    dead = DECLARED_TEETH - fired_teeth
+    if dead:
+        failures.append(f"dead teeth never exercised in firing direction: {sorted(dead)}")
+
+    print()
+    print(f"checked {checked} fixture(s); teeth exercised: {sorted(fired_teeth)}")
+
+    if failures:
+        print("\nFAIL:", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print("OK: value-flow subsystem contract holds; all teeth fire in both directions.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Binds the estate's **economic spine** (Economic Prophet omnirisk/EP + the in-flight welfare-annealing dynamics) **UPWARD** into the GAIA world model and the digital-twin hierarchy — the integration that should have been automatic. The economic spine becomes the **value-flow subsystem of the world model**.

Landed here (not in economic-prophet) per **ADR-0002**: GAIA is the home for world-model layer/composition contracts, and `schemas/economy/**` is the established GAIA↔EP soft-ref surface (`economy_observation.v1`). The binding is *upward* — the world model owns the biosphere/resource state and the twin hierarchy the spine READS.

**Consume-not-fork:** economic-prophet kernels and `feat/welfare-annealing` are referenced by pinned soft-ref; nothing is vendored. No live/shared-state access — static fixtures only.

## The four bindings (teeth both directions)

| Tooth | Binding | Fires when | Verdict |
| --- | --- | --- | --- |
| `T1-CONST` | carrying-capacity ↔ biosphere | carrying-capacity is a hardcoded constant, not a world-model read | REJECT |
| `T1-RESERVE` | carrying-capacity/ecosystem ↔ biosphere | a non-renewable draw takes a stock below the declared reserve floor | FLAG (planetary-boundary breach) |
| `T2-CONSERVE` | twin-hierarchy value conservation (IC-1) | a cross-scale flow creates value out of nothing | REJECT |
| `T3-QOL` | QoL ↔ human digital twin | a QoL dimension is not derivable from human-twin state | REJECT |
| `T4-REGEN` | ecosystem ↔ biosphere | a renewable regeneration rate is a constant, not a world-model read | REJECT |

The validator also fails if any declared tooth is **never** exercised in the firing direction (no dead teeth), and asserts admitted fixtures fire **no** tooth. Deterministic, Python stdlib only.

## Contents

- `docs/decisions/ADR-0003-economic-spine-value-flow-subsystem.md`
- `docs/contracts/VALUE_FLOW_SUBSYSTEM_CONTRACT.md`
- `schemas/economy/value_flow_binding.v1.schema.json`, `schemas/economy/twin_scale_transfer.v1.schema.json`
- `examples/economy/value_flow/**` — 7 fixtures (valid + invalid + flag), one per tooth, both directions
- `scripts/validate_value_flow_subsystem.py` + `.github/workflows/value-flow-subsystem.yml`

## Cross-reference

The **ontogenesis / Systema Concept Entry** concept-governance work (sibling agent) governs the vocabulary used here (`carrying_capacity`, `natural_capital`, `renewable_harvest`, `qol_index`, twin-scale terms). This PR *references* those governed concepts and does not duplicate them; terms should resolve against the ontogenesis concept-governance PR once landed.
