### PR TITLE
fix(geospatial): make world_claim_ingest.py emit schema-conformant WorldClaims

### DIFF
--- a/.github/workflows/contract-fixtures.yml
+++ b/.github/workflows/contract-fixtures.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/validate_multidomain_fixtures.py'
       - 'scripts/validate_bounded_osm_source_adapter.py'
       - 'scripts/validate_chronos_carrier_fixtures.py'
+      - 'scripts/validate_world_claim_ingest_schema_conformance.py'
       - 'scripts/ofif_to_gaia_bridge.py'
       - 'scripts/check_ofif_bridge_invariants.py'
       - 'scripts/soil_intelligence_fusion.py'
@@ -28,6 +29,7 @@ on:
       - 'scripts/validate_multidomain_fixtures.py'
       - 'scripts/validate_bounded_osm_source_adapter.py'
       - 'scripts/validate_chronos_carrier_fixtures.py'
+      - 'scripts/validate_world_claim_ingest_schema_conformance.py'
       - 'scripts/ofif_to_gaia_bridge.py'
       - 'scripts/check_ofif_bridge_invariants.py'
       - 'scripts/soil_intelligence_fusion.py'
@@ -51,6 +53,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
+      - name: Install validation dependencies
+        run: python3 -m pip install jsonschema==4.23.0
 
       - name: Validate contract fixture pairs
         run: python3 scripts/validate_contract_fixtures.py
@@ -91,6 +96,9 @@ jobs:
 
       - name: Validate CHRONOS carrier extension fixtures (WorldClaim/FusionExplanation)
         run: python3 scripts/validate_chronos_carrier_fixtures.py
+
+      - name: Validate world_claim_ingest.py output against full v1 schemas
+        run: python3 scripts/validate_world_claim_ingest_schema_conformance.py
 
       - name: Convert OFIF observation into GAIA artifact
         run: |

--- a/geospatial/world_claim_ingest.py
+++ b/geospatial/world_claim_ingest.py
@@ -134,7 +134,11 @@ def build_geo_anchor(feature: Dict[str, Any], created_at: str) -> Dict[str, Any]
         anchor["bbox"] = feature["bbox"]
     if isinstance(feature.get("h3_cells"), list):
         anchor["h3_cells"] = feature["h3_cells"]
-    anchor["source_ref"] = osm_source_ref(feature["osm_type"], feature["osm_id"])
+    # NOTE: no "source_ref" here. schemas/geospatial/world_claim.v1.schema.json
+    # embeds GeoAnchor inline under WorldClaim.geo_anchor with
+    # additionalProperties=false and no "source_ref" property (source
+    # attribution for the anchor's owning feature belongs on SourceEvidence,
+    # which does carry source_ref). Adding it here breaks schema conformance.
     return anchor
 
 

--- a/scripts/validate_world_claim_ingest_schema_conformance.py
+++ b/scripts/validate_world_claim_ingest_schema_conformance.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Validate that geospatial/world_claim_ingest.py emits schema-conformant WorldClaims.
+
+SocioProphet/gaia-world-model's Propose step (geospatial/world_claim_ingest.py)
+must emit WorldClaim / SourceEvidence / FusionExplanation records that validate
+against the canonical v1 JSON Schemas:
+
+  - schemas/geospatial/world_claim.v1.schema.json
+  - schemas/geospatial/source_evidence.v1.schema.json
+  - schemas/geospatial/fusion_explanation.v1.schema.json
+
+socioprophet-web/client-vue/src/gaia/worldClaim.ts mirrors these same schemas
+field-for-field for the cockpit, so schema conformance here is also cockpit
+contract conformance.
+
+Unlike scripts/validate_contract_fixtures.py and
+scripts/validate_chronos_carrier_fixtures.py (dependency-light by design,
+jsonschema optional), this validator requires `jsonschema` and hard-fails
+without it, matching the precedent in
+scripts/validate_operational_topology_blast_radius.py. See
+.github/workflows/contract-fixtures.yml, which pins jsonschema==4.23.0.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).resolve().parents[1]
+
+WORLD_CLAIM_SCHEMA = ROOT / "schemas/geospatial/world_claim.v1.schema.json"
+SOURCE_EVIDENCE_SCHEMA = ROOT / "schemas/geospatial/source_evidence.v1.schema.json"
+FUSION_EXPLANATION_SCHEMA = ROOT / "schemas/geospatial/fusion_explanation.v1.schema.json"
+
+INGEST_SCRIPT = ROOT / "geospatial/world_claim_ingest.py"
+INPUT_FIXTURE = ROOT / "fixtures/geospatial/osm-feature-world-claim-input.sample.v1.json"
+GOLDEN_FIXTURE = ROOT / "fixtures/geospatial/osm-feature-world-claim.sample.v1.json"
+RUNTIME_OUTPUT = Path("/tmp/gaia-world-claim-ingest-schema-conformance-output.json")
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"ERROR: {message}")
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        fail(f"missing file: {path}")
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+
+def run_ingest(output_path: Path) -> Dict[str, Any]:
+    """Run the real world_claim_ingest.py CLI entrypoint against the fixture input."""
+    subprocess.run(
+        [sys.executable, str(INGEST_SCRIPT), str(INPUT_FIXTURE), str(output_path)],
+        check=True,
+        cwd=ROOT,
+    )
+    return load_json(output_path)
+
+
+def validate_bundle(
+    label: str,
+    doc: Dict[str, Any],
+    claim_validator: Draft202012Validator,
+    evidence_validator: Draft202012Validator,
+    trace_validator: Draft202012Validator,
+) -> int:
+    """Validate every claim/evidence/trace record in a world_claim_ingest.py-style bundle."""
+    checked = 0
+    for claim in doc.get("claims", []):
+        errors = list(claim_validator.iter_errors(claim))
+        if errors:
+            details = "; ".join(f"{list(e.path)}: {e.message}" for e in errors)
+            fail(f"{label}: claim {claim.get('claim_id')!r} fails world_claim.v1 schema: {details}")
+        checked += 1
+    for evidence in doc.get("evidence_records", []):
+        errors = list(evidence_validator.iter_errors(evidence))
+        if errors:
+            details = "; ".join(f"{list(e.path)}: {e.message}" for e in errors)
+            fail(f"{label}: evidence {evidence.get('evidence_id')!r} fails source_evidence.v1 schema: {details}")
+        checked += 1
+    for trace in doc.get("explanation_traces", []):
+        errors = list(trace_validator.iter_errors(trace))
+        if errors:
+            details = "; ".join(f"{list(e.path)}: {e.message}" for e in errors)
+            fail(f"{label}: trace {trace.get('trace_id')!r} fails fusion_explanation.v1 schema: {details}")
+        checked += 1
+    if checked == 0:
+        fail(f"{label}: expected at least one claim/evidence/trace record, found none")
+    return checked
+
+
+def check_no_stray_anchor_source_ref(label: str, doc: Dict[str, Any]) -> None:
+    """Regression guard for the specific non-conformance this validator was added for.
+
+    GeoAnchor, when embedded inline under WorldClaim.geo_anchor, does not
+    declare a "source_ref" property and additionalProperties=false rejects
+    it. Assert this directly (in addition to the schema check above) so the
+    failure mode is self-explanatory if it ever regresses.
+    """
+    for claim in doc.get("claims", []):
+        anchor = claim.get("geo_anchor", {})
+        if "source_ref" in anchor:
+            fail(
+                f"{label}: claim {claim.get('claim_id')!r} geo_anchor carries 'source_ref', "
+                "which is not an allowed property of the inline WorldClaim.geo_anchor schema"
+            )
+
+
+def main() -> int:
+    claim_validator = Draft202012Validator(load_json(WORLD_CLAIM_SCHEMA))
+    evidence_validator = Draft202012Validator(load_json(SOURCE_EVIDENCE_SCHEMA))
+    trace_validator = Draft202012Validator(load_json(FUSION_EXPLANATION_SCHEMA))
+
+    bundles: List[Tuple[str, Dict[str, Any]]] = [
+        (str(RUNTIME_OUTPUT), run_ingest(RUNTIME_OUTPUT)),
+        (str(GOLDEN_FIXTURE), load_json(GOLDEN_FIXTURE)),
+    ]
+
+    checked = 0
+    for label, doc in bundles:
+        checked += validate_bundle(label, doc, claim_validator, evidence_validator, trace_validator)
+        check_no_stray_anchor_source_ref(label, doc)
+
+    print(
+        f"validated {checked} WorldClaim/SourceEvidence/FusionExplanation record(s) "
+        "against the full v1 schemas (world_claim_ingest.py runtime output + golden fixture)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

`geospatial/world_claim_ingest.py`'s `build_geo_anchor()` added a
`source_ref` field onto every `GeoAnchor` it emitted. The canonical
`WorldClaim` contract (`schemas/geospatial/world_claim.v1.schema.json`)
embeds `GeoAnchor` inline under `WorldClaim.geo_anchor` with
`additionalProperties: false` and does **not** declare `source_ref` there
(only `anchor_id`, `anchor_type`, `geometry`, `bbox`, `h3_cells`, `crs`,
`temporal` are allowed). Validating the script's actual output against the
schema with `jsonschema` confirmed every emitted claim failed with:

```
['geo_anchor'] Additional properties are not allowed ('source_ref' was unexpected)
```

This was the only non-conformance found — `evidence_records` and
`explanation_traces` already validated cleanly against
`source_evidence.v1.schema.json` / `fusion_explanation.v1.schema.json`.

Cross-checked against the cockpit's mirrored contract at
`socioprophet-web/client-vue/src/gaia/worldClaim.ts` (in the
`socioprophet-web` repo) — its `GeoAnchor` type also has no `source_ref`
field, confirming the schema (not the old script behavior) is authoritative.
Source attribution for the anchor's owning feature was already redundantly
covered by `SourceEvidence.source_ref`.

## Changes

- `geospatial/world_claim_ingest.py`: drop the non-conformant
  `anchor["source_ref"]` assignment in `build_geo_anchor()`.
- `scripts/validate_world_claim_ingest_schema_conformance.py`: new
  dependency-light-style validator (matching
  `scripts/validate_operational_topology_blast_radius.py`'s hard
  `jsonschema` dependency) that runs the real ingest CLI against the
  fixture input and validates every emitted `claim`/`evidence`/`trace`
  record against the full v1 schemas, plus the golden fixture
  (`fixtures/geospatial/osm-feature-world-claim.sample.v1.json`).
- `.github/workflows/contract-fixtures.yml`: install `jsonschema==4.23.0`
  (same pin as `operational-topology.yml`) and run the new validator.

## Test plan

- [x] `python3 geospatial/world_claim_ingest.py fixtures/geospatial/osm-feature-world-claim-input.sample.v1.json /tmp/out.json` still succeeds and produces the documented deterministic fields (`policy_status.status=proposed`, `confidence_score=0.85`, etc.)
- [x] `python3 scripts/validate_world_claim_ingest_schema_conformance.py` — validates 6 records (3 from runtime output + 3 from golden fixture) against the full v1 schemas, 0 errors
- [x] `python3 scripts/validate_contract_fixtures.py`, `scripts/validate_chronos_carrier_fixtures.py`, `scripts/validate_multidomain_fixtures.py`, `scripts/validate_bounded_osm_source_adapter.py`, `scripts/validate_repo.py` all still pass unchanged
- [x] `python3 -m py_compile` on both changed/added Python files